### PR TITLE
Setup gitlab job to test build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: ci
+
+on: [pull_request] # yamllint disable-line rule:truthy
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+  checks: write # Used to annotate code in the PR
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+      with:
+        go-version-file: "go.mod"
+    - name: build
+      run: |
+        make build


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow to run a build job triggered by pull requests.

Added a new workflow file (.github/workflows/ci.yaml) to execute a build job.
Configured concurrency and permissions to manage PR build jobs.
Included steps for checking out the repository, setting up the Go environment, and running the build command.