### PR TITLE
Add gofmt check as part of CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,26 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
-      with:
-        go-version-file: "go.mod"
-    - name: build
-      run: |
-        make build
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: "go.mod"
+      - name: build
+        run: |
+          make build
+  linting:
+    needs: [build]
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: "go.mod"
+      - name: gofmt
+        run: |
+          gofmt_out=$(gofmt -d $(find * -name '*.go' ! -path 'vendor/*'))
+          if [[ -n "$gofmt_out" ]]; then
+              failed=1
+          fi
+          echo "$gofmt_out"


### PR DESCRIPTION
Since golang cares about formatting, enabling a CI job which can run gofmt and see if there are files which needs formatting, if so, fail the CI check.

Signed-off-by: vinamra28 <vinjain@redhat.com>