### PR TITLE
Keep pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -3,8 +3,6 @@ name: Build and Push Docker Image
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
PRs from forks fails docker build as they try to access the secrets which github doesn't allows when the event `pull_request` is emitted whereas the same is accessible on the event `pull_request_target`.


Signed-off-by: vinamra28 <vinjain@redhat.com>