### PR TITLE
Run lint on PRs for code quality

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ defaults:
 permissions:
   contents: read
   checks: write # Used to annotate code in the PR
+  pull-requests: read
 
 jobs:
   build:
@@ -42,6 +43,15 @@ jobs:
               failed=1
           fi
           echo "$gofmt_out"
+      - name: mockgen
+        run: |
+          make mockgen
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6.0.1
+        with:
+          install-mode: "goinstall"
+          version: v1.64.8
+          
   unit-tests:
     name: unit-tests
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
   enable:
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - ginkgolinter
     - goconst
     - gocyclo

--- a/internal/controller/group_controller.go
+++ b/internal/controller/group_controller.go
@@ -212,7 +212,7 @@ func (r *GroupReconciler) processUsers(ctx context.Context,
 	}
 
 	// process existing team members to find users to remove
-	for userID, _ := range existingTeamMembers {
+	for userID := range existingTeamMembers {
 		if !slices.Contains(userIDsToSync, userID) {
 			usersToRemove = append(usersToRemove, userID)
 		}

--- a/pkg/clients/fivetran/users.go
+++ b/pkg/clients/fivetran/users.go
@@ -14,7 +14,8 @@ import (
 // returns 2 maps where:
 // 1st map will have ID as key in order to map with team membership response
 // and 2nd will have email as key
-func (fc *FivetranClient) FetchAllUsers(ctx context.Context) (map[string]*structs.User, map[string]*structs.User, error) {
+func (fc *FivetranClient) FetchAllUsers(ctx context.Context) (
+	map[string]*structs.User, map[string]*structs.User, error) {
 	log := logger.Logger(ctx).WithField("service", "fivetran")
 
 	usersEmailMap := make(map[string]*structs.User, 0)

--- a/pkg/clients/ldap/client_test.go
+++ b/pkg/clients/ldap/client_test.go
@@ -60,7 +60,9 @@ func startMockLDAPServer(t *testing.T) (addr string, stop func()) {
 				}
 			}
 			go func(c net.Conn) {
-				defer c.Close()
+				defer func() {
+					_ = c.Close()
+				}()
 				// Minimal LDAP handshake: just close after a short delay
 				time.Sleep(100 * time.Millisecond)
 			}(conn)
@@ -68,6 +70,6 @@ func startMockLDAPServer(t *testing.T) (addr string, stop func()) {
 	}()
 	return ln.Addr().String(), func() {
 		close(done)
-		ln.Close()
+		_ = ln.Close()
 	}
 }

--- a/pkg/clients/ldap/user_test.go
+++ b/pkg/clients/ldap/user_test.go
@@ -62,7 +62,8 @@ func (suite *LDAPTestSuite) TestGetUserLDAPData() {
 	}
 
 	assertions.Equal("uid=%s,ou=users,dc=example,dc=com", ldapConn.GetUserDN(), "Expected userDN to match the format")
-	assertions.Equal("ou=adhoc,ou=managedGroups,dc=example,dc=com", ldapConn.GetBaseDN(), "Expected baseDN to match the format")
+	assertions.Equal("ou=adhoc,ou=managedGroups,dc=example,dc=com",
+		ldapConn.GetBaseDN(), "Expected baseDN to match the format")
 
 	resp, err := ldapConn.GetUserLDAPData(suite.ctx, "testuser")
 
@@ -130,7 +131,8 @@ func (suite *LDAPTestSuite) TestSearchError() {
 	}
 
 	suite.ldapClient.EXPECT().IsClosing().Return(false).Times(1)
-	suite.ldapClient.EXPECT().Search(gomock.Any()).Return(nil, ldap.NewError(ldap.LDAPResultOperationsError, errors.New("search error"))).Times(1)
+	suite.ldapClient.EXPECT().Search(gomock.Any()).
+		Return(nil, ldap.NewError(ldap.LDAPResultOperationsError, errors.New("search error"))).Times(1)
 
 	resp, err := ldapConn.GetUserLDAPData(suite.ctx, "testuser")
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -64,14 +64,14 @@ func TestLoadConfigFromYAML(t *testing.T) {
 
 	key := "CACHE_REDIS_PASSWORD"
 
-	os.Setenv(key, "redispassword")
+	_ = os.Setenv(key, "redispassword")
 
 	err := NewConfig(NewOptions("yaml", "./testdata", "default")).Load("dev", &c)
 	assert.Nil(t, err)
 
 	assertConfigs(t, &c)
 
-	os.Unsetenv(key)
+	_ = os.Unsetenv(key)
 }
 
 func TestLoadConfigFromTOML(t *testing.T) {
@@ -79,18 +79,18 @@ func TestLoadConfigFromTOML(t *testing.T) {
 
 	key := "CACHE_REDIS_PASSWORD"
 
-	os.Setenv(key, "redispassword")
+	_ = os.Setenv(key, "redispassword")
 
 	err := NewConfig(NewOptions("toml", "./testdata", "defaulttoml")).Load("devtoml", &c)
 	assert.Nil(t, err)
 
 	assertConfigs(t, &c)
 
-	os.Unsetenv(key)
+	_ = os.Unsetenv(key)
 }
 
 func assertConfigs(t *testing.T, c *TestConfig) {
-	// assert that app environment got overriden with dev.toml
+	// assert that app environment got overridden with dev.toml
 	assert.Equal(t, "dev", c.AppEnv)
 
 	// asserts that cache driver is redis

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -208,7 +208,7 @@ func TestMapToStruct_InvalidConversions(t *testing.T) {
 func TestMapToStruct_JSONTagWithOptions(t *testing.T) {
 	type TagStruct struct {
 		Name string `json:"name,omitempty"`
-		Age  int    `json:"age,required"`
+		Age  int    `json:"age"`
 	}
 
 	data := map[string]interface{}{


### PR DESCRIPTION
It is necessary to run lint checks on incoming PRs to ensure that best practices are always maintained during the development.

Signed-off-by: vinamra28 <vinjain@redhat.com>