### PR TITLE
Fix parsing of secrets and lint issues and Watch CRs from the specified namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	k8sCache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -132,6 +133,11 @@ func main() {
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
+	watchedNs := os.Getenv("WATCHED_NAMESPACE")
+	if watchedNs == "" {
+		watchedNs = "usernaut"
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
@@ -139,6 +145,11 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "dd1e5158.usernaut.dev",
+		Cache: k8sCache.Options{
+			DefaultNamespaces: map[string]k8sCache.Config{
+				watchedNs: {},
+			},
+		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,8 +1,9 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: manager-role
+  namespace: usernaut
 rules:
 - apiGroups:
   - usernaut.dev

--- a/internal/controller/group_controller.go
+++ b/internal/controller/group_controller.go
@@ -53,9 +53,10 @@ type GroupReconciler struct {
 	allLdapUserData map[string]*structs.LDAPUser
 }
 
-// +kubebuilder:rbac:groups=usernaut.dev,resources=groups,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=usernaut.dev,resources=groups/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=usernaut.dev,resources=groups/finalizers,verbs=update
+//nolint:lll
+// +kubebuilder:rbac:groups=usernaut.dev,namespace=usernaut,resources=groups,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=usernaut.dev,namespace=usernaut,resources=groups/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=usernaut.dev,namespace=usernaut,resources=groups/finalizers,verbs=update
 
 func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	ctx = logger.WithRequestId(ctx, controller.ReconcileIDFromContext(ctx))

--- a/internal/controller/group_controller_test.go
+++ b/internal/controller/group_controller_test.go
@@ -156,7 +156,8 @@ var _ = Describe("Group Controller", func() {
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			// TODO: ideally err should be nil if the reconciliation is successful, we need to mock the backend client to return a successful response.
+			// TODO: ideally err should be nil if the reconciliation is successful,
+			// we need to mock the backend client to return a successful response.
 			Expect(err).To(HaveOccurred())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -83,7 +83,11 @@ func (c *Config) Load(env string, config interface{}) error {
 	if err := c.loadByConfigName(c.opts.defaultConfigFileName, config); err != nil {
 		return err
 	}
-	return c.loadByConfigName(env, config)
+	if err := c.loadByConfigName(env, config); err != nil {
+		return err
+	}
+	SubstituteConfigValues(reflect.ValueOf(config))
+	return nil
 }
 
 // SubstituteConfigValues recursively walks through the config struct and replaces
@@ -174,7 +178,5 @@ func (c *Config) loadByConfigName(configName string, config interface{}) error {
 	if err := c.viper.Unmarshal(config); err != nil {
 		return err
 	}
-	// Substitute env| and file| values after unmarshalling
-	SubstituteConfigValues(reflect.ValueOf(config))
 	return nil
 }


### PR DESCRIPTION
If the default config contains some wildcards which are being overriden
in the environment specific config, while parsing the default config,
code was trying to resolve the default config first and then the
environment specific config, thus failing the config parsing.

Rearranging the config parsing and variable substitution in the order
of: parse default config, parse env specific config and then resolve the
variables which aren't already parsed.
  
---

 As of now, usernaut used to watch the CRs across namespaces but as the
tool is specific to organization and not specific to the team so having
them in a namespace helps manage at a single place.
    
Adding a filter for watched namespace.
    
Signed-off-by: vinamra28 <vinjain@redhat.com>
