### PR TITLE
Pushing changes for Atlan backend

### DIFF
--- a/appconfig/default.yaml
+++ b/appconfig/default.yaml
@@ -30,7 +30,6 @@ pattern:
     - input: "^([^\\_]+)$"
       output: "$1"
 
-
 app:
   name: "usernaut"
   version: "0.0.1"
@@ -81,3 +80,9 @@ backends:
       cert_path: "/path/to/usernaut.crt"
       private_key_path: "/path/to/usernaut.pem"
       service_account_name: test-service-account
+  - name: atlan
+    type: "atlan"
+    enabled: true
+    connection:
+      url: "https://yourcompany.atlan.com"
+      api_token: file|path/to/api_token

--- a/pkg/clients/atlan/client.go
+++ b/pkg/clients/atlan/client.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atlan
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/gojek/heimdall/v7"
+	"github.com/redhat-data-and-ai/usernaut/pkg/request"
+	"github.com/redhat-data-and-ai/usernaut/pkg/request/httpclient"
+	"github.com/redhat-data-and-ai/usernaut/pkg/utils"
+)
+
+// AtlanClient is a simple HTTP client for Atlan API
+type AtlanClient struct {
+	client   heimdall.Doer
+	url      string
+	apiToken string
+}
+
+// AtlanConfig holds the configuration needed to connect to Atlan
+type AtlanConfig struct {
+	URL      string `json:"url"`
+	APIToken string `json:"api_token"`
+}
+
+// NewClient creates a new Atlan client with simple API token authentication
+func NewClient(atlanAppConfig map[string]interface{},
+	connectionPoolConfig httpclient.ConnectionPoolConfig,
+	hystrixResiliencyConfig httpclient.HystrixResiliencyConfig) (*AtlanClient, error) {
+
+	atlanConfig := AtlanConfig{}
+	if err := utils.MapToStruct(atlanAppConfig, &atlanConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse atlan configuration: %w", err)
+	}
+
+	// Validate required fields
+	if atlanConfig.URL == "" {
+		return nil, fmt.Errorf("atlan configuration is missing required field: URL")
+	}
+	if atlanConfig.APIToken == "" {
+		return nil, fmt.Errorf("atlan configuration is missing required field: APIToken")
+	}
+
+	// Initialize HTTP client without certificates (Atlan uses API token, not certs)
+	client, err := httpclient.InitializeClient(
+		"atlan",
+		connectionPoolConfig,
+		hystrixResiliencyConfig,
+		heimdall.NewRetrier(heimdall.NewConstantBackoff(100*time.Millisecond, 50*time.Millisecond)), // retry logic
+		3,
+		nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize http client: %w", err)
+	}
+
+	return &AtlanClient{
+		client:   client,
+		url:      atlanConfig.URL,
+		apiToken: atlanConfig.APIToken,
+	}, nil
+}
+
+// sendRequest makes an HTTP request to the Atlan API with proper authentication
+func (aC *AtlanClient) sendRequest(ctx context.Context, url string, method string, body interface{},
+	headers map[string]string, methodName string) ([]byte, int, error) {
+	requestBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	req, err := request.NewRequest(ctx, method, url, requestBody)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if headers == nil {
+		headers = make(map[string]string)
+	}
+	headers["Authorization"] = "Bearer " + aC.apiToken
+	headers["Content-Type"] = "application/json"
+	headers["Accept"] = "application/json"
+
+	req.SetHeaders(headers)
+
+	response, statusCode, err := req.MakeRequest(aC.client, methodName, "atlan")
+	if err != nil {
+		return nil, statusCode, fmt.Errorf("request failed: %w", err)
+	}
+
+	if !slices.Contains([]int{http.StatusOK, http.StatusCreated}, statusCode) {
+		return nil, statusCode, fmt.Errorf("unexpected status code: %d", statusCode)
+	}
+
+	return response, statusCode, nil
+}

--- a/pkg/clients/atlan/team_membership.go
+++ b/pkg/clients/atlan/team_membership.go
@@ -7,16 +7,16 @@ import (
 )
 
 func (ac *AtlanClient) FetchTeamMembersByTeamID(ctx context.Context, teamID string) (map[string]*structs.User, error) {
-	// Team membership is synced via LDAP, return empty map like Rover does
+	// Team membership is synced via LDAP, returning empty map
 	return make(map[string]*structs.User), nil
 }
 
 func (ac *AtlanClient) AddUserToTeam(ctx context.Context, teamID, userID string) error {
-	// Team membership is synced via LDAP, return nil like Rover does
+	// Team membership is synced via LDAP, returning nil
 	return nil
 }
 
 func (ac *AtlanClient) RemoveUserFromTeam(ctx context.Context, teamID, userID string) error {
-	// Team membership is synced via LDAP, return nil like Rover does
+	// Team membership is synced via LDAP, returning nil
 	return nil
 }

--- a/pkg/clients/atlan/team_membership.go
+++ b/pkg/clients/atlan/team_membership.go
@@ -1,0 +1,22 @@
+package atlan
+
+import (
+	"context"
+
+	"github.com/redhat-data-and-ai/usernaut/pkg/common/structs"
+)
+
+func (ac *AtlanClient) FetchTeamMembersByTeamID(ctx context.Context, teamID string) (map[string]*structs.User, error) {
+	// Team membership is synced via LDAP, return empty map like Rover does
+	return make(map[string]*structs.User), nil
+}
+
+func (ac *AtlanClient) AddUserToTeam(ctx context.Context, teamID, userID string) error {
+	// Team membership is synced via LDAP, return nil like Rover does
+	return nil
+}
+
+func (ac *AtlanClient) RemoveUserFromTeam(ctx context.Context, teamID, userID string) error {
+	// Team membership is synced via LDAP, return nil like Rover does
+	return nil
+}

--- a/pkg/clients/atlan/teams.go
+++ b/pkg/clients/atlan/teams.go
@@ -1,0 +1,125 @@
+package atlan
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/redhat-data-and-ai/usernaut/pkg/common/structs"
+	"github.com/redhat-data-and-ai/usernaut/pkg/logger"
+	"github.com/sirupsen/logrus"
+)
+
+type AtlanGroup struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type AtlanGroupsResponse struct {
+	TotalRecord  int          `json:"totalRecord"`
+	FilterRecord int          `json:"filterRecord"`
+	Records      []AtlanGroup `json:"records"`
+}
+
+func (ac *AtlanClient) FetchAllTeams(ctx context.Context) (map[string]structs.Team, error) {
+	log := logger.Logger(ctx).WithField("service", "atlan")
+	log.Info("fetching all teams from Atlan")
+
+	url := fmt.Sprintf("%s/api/service/v2/groups?columns=name", ac.url)
+	response, statusCode, err := ac.sendRequest(ctx, url, http.MethodGet, nil, nil, "FetchAllTeams")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch teams from Atlan: %w", err)
+	}
+
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d when fetching teams from Atlan", statusCode)
+	}
+
+	var apiResponse AtlanGroupsResponse
+	if err := json.Unmarshal(response, &apiResponse); err != nil {
+		return nil, fmt.Errorf("failed to parse response from Atlan: %w", err)
+	}
+
+	teams := make(map[string]structs.Team)
+	for _, group := range apiResponse.Records {
+		teams[group.ID] = structs.Team{
+			ID:   group.ID,
+			Name: group.Name,
+		}
+	}
+
+	log.WithField("team_count", len(teams)).Info("successfully fetched teams from Atlan")
+	return teams, nil
+}
+
+func (ac *AtlanClient) CreateTeam(ctx context.Context, team *structs.Team) (*structs.Team, error) {
+	log := logger.Logger(ctx).WithFields(logrus.Fields{
+		"service":   "atlan",
+		"team_name": team.Name,
+	})
+
+	log.Info("creating team in Atlan")
+
+	url := fmt.Sprintf("%s/api/service/groups", ac.url)
+
+	// Convert team name to valid internal name as per Atlan guidelines (lowercase, alphanumeric + underscore only)
+	internalName := strings.ToLower(strings.ReplaceAll(team.Name, " ", "_"))
+	internalName = strings.ReplaceAll(internalName, "-", "_")
+
+	requestBody := map[string]interface{}{
+		"group": map[string]interface{}{
+			"attributes": map[string]interface{}{
+				"alias":     []string{team.Name},
+				"isDefault": []string{"false"},
+			},
+			"name": internalName, // Sanitized internal name
+		},
+	}
+
+	response, statusCode, err := ac.sendRequest(ctx, url, http.MethodPost, requestBody, nil, "CreateTeam")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create team in Atlan: %w", err)
+	}
+
+	if statusCode != http.StatusCreated && statusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d when creating team in Atlan", statusCode)
+	}
+
+	var createdGroup AtlanGroup
+	if err := json.Unmarshal(response, &createdGroup); err != nil {
+		return nil, fmt.Errorf("failed to parse created team response from Atlan: %w", err)
+	}
+
+	log.WithField("team_id", createdGroup.ID).Info("successfully created team in Atlan")
+	return &structs.Team{
+		ID:   createdGroup.ID,
+		Name: createdGroup.Name,
+	}, nil
+}
+
+func (ac *AtlanClient) DeleteTeamByID(ctx context.Context, teamID string) error {
+	log := logger.Logger(ctx).WithFields(logrus.Fields{
+		"service": "atlan",
+		"team_id": teamID,
+	})
+	log.Info("deleting team from Atlan")
+
+	url := fmt.Sprintf("%s/api/service/groups/%s", ac.url, teamID)
+	_, statusCode, err := ac.sendRequest(ctx, url, http.MethodDelete, nil, nil, "DeleteTeamByID")
+	if err != nil {
+		return fmt.Errorf("failed to delete team from Atlan: %w", err)
+	}
+
+	if statusCode != http.StatusOK && statusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected status code %d when deleting team from Atlan", statusCode)
+	}
+
+	log.Info("successfully deleted team from Atlan")
+	return nil
+}
+
+func (ac *AtlanClient) FetchTeamDetails(ctx context.Context, teamID string) (*structs.Team, error) {
+	return nil, fmt.Errorf("FetchTeamDetails is not implemented for Atlan")
+}

--- a/pkg/clients/atlan/users.go
+++ b/pkg/clients/atlan/users.go
@@ -1,0 +1,29 @@
+package atlan
+
+import (
+	"context"
+
+	"github.com/redhat-data-and-ai/usernaut/pkg/common/structs"
+)
+
+func (ac *AtlanClient) FetchAllUsers(ctx context.Context) (map[string]*structs.User, map[string]*structs.User, error) {
+	// Users are synced via LDAP, return empty maps like Rover does
+	return make(map[string]*structs.User), make(map[string]*structs.User), nil
+}
+
+func (ac *AtlanClient) FetchUserDetails(ctx context.Context, userID string) (*structs.User, error) {
+	// Users are synced via LDAP, return empty user like Rover does
+	return &structs.User{}, nil
+}
+
+func (ac *AtlanClient) CreateUser(ctx context.Context, u *structs.User) (*structs.User, error) {
+	// Users are synced via LDAP, return minimal user struct like Rover does
+	return &structs.User{
+		ID: u.UserName,
+	}, nil
+}
+
+func (ac *AtlanClient) DeleteUser(ctx context.Context, userID string) error {
+	// Users are synced via LDAP, return nil like Rover does
+	return nil
+}

--- a/pkg/clients/atlan/users.go
+++ b/pkg/clients/atlan/users.go
@@ -7,23 +7,23 @@ import (
 )
 
 func (ac *AtlanClient) FetchAllUsers(ctx context.Context) (map[string]*structs.User, map[string]*structs.User, error) {
-	// Users are synced via LDAP, return empty maps like Rover does
+	// Users are synced via LDAP, return empty maps
 	return make(map[string]*structs.User), make(map[string]*structs.User), nil
 }
 
 func (ac *AtlanClient) FetchUserDetails(ctx context.Context, userID string) (*structs.User, error) {
-	// Users are synced via LDAP, return empty user like Rover does
+	// Users are synced via LDAP, return empty user
 	return &structs.User{}, nil
 }
 
 func (ac *AtlanClient) CreateUser(ctx context.Context, u *structs.User) (*structs.User, error) {
-	// Users are synced via LDAP, return minimal user struct like Rover does
+	// Users are synced via LDAP, return minimal user struct
 	return &structs.User{
 		ID: u.UserName,
 	}, nil
 }
 
 func (ac *AtlanClient) DeleteUser(ctx context.Context, userID string) error {
-	// Users are synced via LDAP, return nil like Rover does
+	// Users are synced via LDAP, return nil
 	return nil
 }

--- a/pkg/clients/client.go
+++ b/pkg/clients/client.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/redhat-data-and-ai/usernaut/pkg/clients/atlan"
 	"github.com/redhat-data-and-ai/usernaut/pkg/clients/fivetran"
 	redhatrover "github.com/redhat-data-and-ai/usernaut/pkg/clients/redhat_rover"
 	"github.com/redhat-data-and-ai/usernaut/pkg/common/structs"
@@ -88,8 +89,15 @@ func New(backendName, backendType string, backends map[string]map[string]config.
 
 		return redhatrover.NewClient(backend.Connection,
 			appConfig.HttpClient.ConnectionPoolConfig, appConfig.HttpClient.HystrixResiliencyConfig)
+	case "atlan":
+		appConfig, err := config.GetConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		return atlan.NewClient(backend.Connection,
+			appConfig.HttpClient.ConnectionPoolConfig, appConfig.HttpClient.HystrixResiliencyConfig)
 	default:
-		// If no valid backend type is matched, return an error
 		return nil, ErrInvalidBackend
 	}
 }


### PR DESCRIPTION
Key changes -

- Added Atlan as a backend for Usernaut
- Implemented FetchGroups, CreateGroup and DeleteGroup functions
- Added a check in controller to create Atlan group only if rover backend is mentioned for the same group in the CR
- Group Sync and user sync is handled automatically via ldap/rover