### PR TITLE
feat: add DCO commit msg validation to git hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,12 @@ setup-pre-commit:
 		cp ./scripts/pre-commit .git/hooks/pre-commit; \
 		chmod +x .git/hooks/pre-commit;	\
 	fi
+	@if [ ! -f .git/hooks/commit-msg ]; then \
+		echo "Installing commit-msg hook for DCO validation..."; \
+		echo '#!/bin/bash' > .git/hooks/commit-msg; \
+		echo 'bash scripts/check-dco.sh "$$1"' >> .git/hooks/commit-msg; \
+		chmod +x .git/hooks/commit-msg; \
+	fi
 
 .PHONY: install
 install: setup-pre-commit manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.

--- a/scripts/check-dco.sh
+++ b/scripts/check-dco.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# DCO (Developer Certificate of Origin) check script
+# This script validates that commits are properly signed off
+
+# Ensure we're running with bash
+if [ -z "$BASH_VERSION" ]; then
+    echo "This script requires bash. Please run with bash."
+    exit 1
+fi
+
+set -e
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}📝 Checking DCO (Developer Certificate of Origin)...${NC}"
+
+# Get the commit message file (passed as first argument to commit-msg hook)
+COMMIT_MSG_FILE="$1"
+
+if [ -z "$COMMIT_MSG_FILE" ] || [ ! -f "$COMMIT_MSG_FILE" ]; then
+    echo -e "${RED}❌ DCO check failed - no commit message file found${NC}"
+    exit 1
+fi
+
+# Read the commit message
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+
+# Check if commit message contains Signed-off-by line
+if echo "$COMMIT_MSG" | grep -qE "^Signed-off-by: .+ <.+@.+>$"; then
+    echo -e "${GREEN}✅ DCO check passed - commit is signed off${NC}"
+    exit 0
+else
+    echo -e "${RED}❌ DCO check failed - commit must be signed off${NC}"
+    echo -e "${YELLOW}💡 To sign off your commit:${NC}"
+    echo "   git commit --amend --signoff"
+    echo "   # Or for new commits:"
+    echo "   git commit --signoff -m \"your commit message\""
+    echo "   # Or add -s flag:"
+    echo "   git commit -s"
+    echo ""
+    echo -e "${YELLOW}🔧 What is DCO?${NC}"
+    echo "   Developer Certificate of Origin ensures you have the right to"
+    echo "   contribute the code and agree to the project's license terms."
+    echo "   Format: Signed-off-by: Your Name <your.email@example.com>"
+    echo ""
+    echo -e "${YELLOW}📋 Your current commit message:${NC}"
+    echo "---"
+    cat "$COMMIT_MSG_FILE"
+    echo "---"
+    echo ""
+    echo -e "${YELLOW}🔧 To bypass this check (not recommended it will fail PR build):${NC}"
+    echo "   git commit --no-verify"
+    exit 1
+fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Check for sensitive information before commit
+# Pre-commit checks for security and code quality
 
-echo "🔍 Basic checks..."
+echo "🔍 Pre-commit checks..."
 
 # Run the secrets check script
 if bash scripts/check-secrets.sh; then


### PR DESCRIPTION
## Summary

Adds comprehensive DCO (Developer Certificate of Origin) validation to ensure all commits are properly signed off, maintaining legal compliance and contribution accountability.

## Changes

### 🔧 **New DCO Check Script** (`scripts/check-dco.sh`)
- Validates commit messages contain proper `Signed-off-by:` lines
- Provides clear error messages and helpful guidance for developers
- Includes comprehensive validation with proper regex patterns

### ⚙️ **Enhanced Setup Process** (`Makefile`)
- Updates existing `setup-pre-commit` target to include DCO hook installation
- Maintains backward compatibility with current workflow
- Automatically installs commit-msg hook for DCO validation

## Implementation Details

- **Commit-msg Hook**: DCO validation (new)

### **Developer Experience:**
- **Automatic Setup**: `make setup-pre-commit` installs both hooks
- **Clear Guidance**: Helpful error messages with exact fix instructions
- **Git Integration**: Standard git hook behavior, works with all git workflows
- **Simple Bypass**: Standard `--no-verify` option available (discouraged)

## Usage

### **For New Contributors:**
```bash
make setup-pre-commit  # Sets up both pre-commit and DCO hooks
```

### **For Signing Commits:**
```bash
git commit --signoff -m "your commit message"
# or
git commit -s -m "your commit message"
```