### PR TITLE
Run CI only when the required files are changed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,19 @@
 name: ci
 
-on: [pull_request] # yamllint disable-line rule:truthy
+on:
+  pull_request:
+    paths-ignore:
+      - ".gemini/**"
+      - ".github/**"
+      - ".cursor/**"
+      - "Dockerfile"
+      - "config/**"
+      - "hack/**"
+      - ".dockerignore"
+      - ".gitignore"
+      - "*.md"
+      - "LICENSE"
+      - "PROJECT"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -51,7 +64,7 @@ jobs:
         with:
           install-mode: "goinstall"
           version: v1.64.8
-          
+
   unit-tests:
     name: unit-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,11 +14,35 @@ name: "CodeQL"
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - ".gemini/**"
+      - ".github/**"
+      - ".cursor/**"
+      - "Dockerfile"
+      - "config/**"
+      - "hack/**"
+      - ".dockerignore"
+      - ".gitignore"
+      - "*.md"
+      - "LICENSE"
+      - "PROJECT"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
+    paths-ignore:
+      - ".gemini/**"
+      - ".github/**"
+      - ".cursor/**"
+      - "Dockerfile"
+      - "config/**"
+      - "hack/**"
+      - ".dockerignore"
+      - ".gitignore"
+      - "*.md"
+      - "LICENSE"
+      - "PROJECT"
   schedule:
-    - cron: '30 20 * * 2'
+    - cron: "30 20 * * 2"
 
 jobs:
   analyze:
@@ -32,40 +56,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['go']
+        language: ["go"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
+      - name: Checkout repository
+        uses: actions/checkout@v5
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # setup cache to speed up the action
-    - uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/.cache/pip
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-    
+      # setup cache to speed up the action
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.cache/pip
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-      with:
-        go-version-file: "go.mod"
-    - run: |
-        make mockgen build
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: "go.mod"
+      - run: |
+          make mockgen build
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,20 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: "Dependency Review"
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - ".gemini/**"
+      - ".github/**"
+      - ".cursor/**"
+      - "Dockerfile"
+      - "config/**"
+      - "hack/**"
+      - ".dockerignore"
+      - ".gitignore"
+      - "*.md"
+      - "LICENSE"
+      - "PROJECT"
 
 permissions:
   contents: read

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -3,9 +3,29 @@ name: Build and Push Docker Image
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - ".gemini/**"
+      - ".github/**"
+      - ".cursor/**"
+      - "config/**"
+      - "hack/**"
+      - ".gitignore"
+      - "*.md"
+      - "LICENSE"
+      - "PROJECT"
     tags:
       - "v*"
   pull_request_target:
+    paths-ignore:
+      - ".gemini/**"
+      - ".github/**"
+      - ".cursor/**"
+      - "config/**"
+      - "hack/**"
+      - ".gitignore"
+      - "*.md"
+      - "LICENSE"
+      - "PROJECT"
     types:
       - opened
       - reopened


### PR DESCRIPTION
This is the step to optimize the CI to run only in the cases when the required files are changed. This will protect from burning the free credits provided by github when not necessary.