### PR TITLE
API endpoint to expose list of backends

### DIFF
--- a/internal/httpapi/handlers/handlers.go
+++ b/internal/httpapi/handlers/handlers.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/redhat-data-and-ai/usernaut/api/v1alpha1"
+	"github.com/redhat-data-and-ai/usernaut/pkg/config"
+)
+
+type Handlers struct {
+	config *config.AppConfig
+}
+
+func NewHandlers(cfg *config.AppConfig) *Handlers {
+	return &Handlers{
+		config: cfg,
+	}
+}
+
+func (h *Handlers) GetBackends(c *gin.Context) {
+	response := make([]v1alpha1.Backend, 0, len(h.config.Backends))
+
+	for _, backend := range h.config.Backends {
+		if backend.Enabled {
+			response = append(response, v1alpha1.Backend{
+				Name: backend.Name,
+				Type: backend.Type,
+			})
+		}
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/httpapi/server/server.go
+++ b/internal/httpapi/server/server.go
@@ -12,14 +12,16 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/redhat-data-and-ai/usernaut/internal/httpapi/handlers"
 	"github.com/redhat-data-and-ai/usernaut/internal/httpapi/middleware"
 	"github.com/redhat-data-and-ai/usernaut/pkg/config"
 )
 
 type APIServer struct {
-	config *config.AppConfig
-	router *gin.Engine
-	server *http.Server
+	config   *config.AppConfig
+	router   *gin.Engine
+	server   *http.Server
+	handlers *handlers.Handlers
 }
 
 func NewAPIServer(cfg *config.AppConfig) *APIServer {
@@ -45,8 +47,9 @@ func NewAPIServer(cfg *config.AppConfig) *APIServer {
 	router.Use(middleware.CORS(&cfg.APIServer))
 
 	s := &APIServer{
-		config: cfg,
-		router: router,
+		config:   cfg,
+		router:   router,
+		handlers: handlers.NewHandlers(cfg),
 	}
 
 	s.setupRoutes()
@@ -66,6 +69,9 @@ func (s *APIServer) setupRoutes() {
 	v1.Use(middleware.BasicAuth(s.config))
 
 	// add authenticated endpoints accordingly
+
+	v1.GET("/backends", s.handlers.GetBackends)
+
 }
 
 func (s *APIServer) Start() error {


### PR DESCRIPTION
This API endpoint will expose list of available backends in usernaut so that we can map the groups to a valid backend