### PR TITLE
Paginate over teams in fivetran

### DIFF
--- a/pkg/clients/fivetran/teams.go
+++ b/pkg/clients/fivetran/teams.go
@@ -3,33 +3,56 @@ package fivetran
 import (
 	"context"
 
+	"github.com/fivetran/go-fivetran/teams"
 	"github.com/redhat-data-and-ai/usernaut/pkg/common/structs"
 	"github.com/redhat-data-and-ai/usernaut/pkg/logger"
 	"github.com/sirupsen/logrus"
 )
 
-func (fc *FivetranClient) FetchAllTeams(ctx context.Context) (map[string]structs.Team, error) {
-	log := logger.Logger(ctx).WithField("service", "fivetran")
-
-	log.Info("fetching all the teams")
-
-	resp, err := fc.fivetranClient.NewTeamsList().Do(ctx)
-	if err != nil {
-		log.WithError(err).Error("error fetching list of teams")
-		return nil, err
-	}
-
-	log.WithField("total_teams_count", len(resp.Data.Items)).Info("found teams")
-
-	teams := make(map[string]structs.Team, 0)
-	for _, team := range resp.Data.Items {
-		teams[team.Name] = structs.Team{
+// populateTeamsMap populates the provided teams map with team data from the response items
+func populateTeamsMap(teamsMap map[string]structs.Team, items []teams.TeamData) {
+	for _, team := range items {
+		teamsMap[team.Name] = structs.Team{
 			ID:          team.Id,
 			Name:        team.Name,
 			Description: team.Description,
 			Role:        team.Role,
 		}
 	}
+}
+
+func (fc *FivetranClient) FetchAllTeams(ctx context.Context) (map[string]structs.Team, error) {
+	log := logger.Logger(ctx).WithField("service", "fivetran")
+
+	log.Info("fetching all the teams")
+
+	teams := make(map[string]structs.Team)
+	var cursor string
+
+	for {
+		req := fc.fivetranClient.NewTeamsList()
+		if cursor != "" {
+			req.Cursor(cursor)
+		}
+
+		resp, err := req.Do(ctx)
+		if err != nil {
+			log.WithError(err).Error("error fetching list of teams")
+			return nil, err
+		}
+
+		populateTeamsMap(teams, resp.Data.Items)
+
+		if resp.Data.NextCursor == "" {
+			break
+		}
+		cursor = resp.Data.NextCursor
+	}
+
+	log.WithFields(logrus.Fields{
+		"total_teams_count": len(teams),
+	}).Info("found teams")
+
 	return teams, nil
 }
 


### PR DESCRIPTION
By default fivetran returns the list of teams with a limit of 100 and if there are more teams available, we need to paginate over the cursor received.

Implementing the pagination for the FetchAllTeams in fivetran client.