### PR TITLE
Fix deployment manifests for preprod and prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,26 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default/overlays/${USERNAUT_ENV} | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: configure-usernaut-rhplatformtest
+configure-usernaut-rhplatformtest:
+	$(KUSTOMIZE) build config/rbac-admin-sa/overlays/rhplatformtest/ | $(KUBECTL) apply -f -
+	@ENVIRONMENT=rhplatformtest bash ./scripts/configmap.sh
+	$(KUSTOMIZE) build config/manual-rbac/overlays/usernaut-rhplatformtest/ | $(KUBECTL) apply -f -
+
+.PHONY: configure-usernaut-rhprod
+configure-usernaut-rhprod:
+	@ENVIRONMENT=rhprod bash ./scripts/configmap.sh
+	$(KUSTOMIZE) build config/manual-rbac/overlays/usernaut-rhprod/ | $(KUBECTL) apply -f -
+
+.PHONY: destroy-usernaut-rhplatformtest
+destroy-usernaut-rhplatformtest:
+	$(KUSTOMIZE) build config/rbac-admin-sa/overlays/rhplatformtest/ | $(KUBECTL) delete --ignore-not-found -f -
+	$(KUSTOMIZE) build config/manual-rbac/overlays/usernaut-rhplatformtest/ | $(KUBECTL) delete --ignore-not-found -f -
+
+.PHONY: destroy-usernaut-rhprod
+destroy-usernaut-rhprod:
+	$(KUSTOMIZE) build config/manual-rbac/overlays/usernaut-rhprod/ | $(KUBECTL) delete --ignore-not-found -f -
+
 ##@ Dependencies
 
 ## Location to install dependencies to

--- a/config/default/base/kustomization.yaml
+++ b/config/default/base/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - ../../crd
 - ../../rbac
 - ../../manager
+- ../../redis
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/default/overlays/rhplatformtest/kustomization.yaml
+++ b/config/default/overlays/rhplatformtest/kustomization.yaml
@@ -1,6 +1,6 @@
-nameSuffix: -platformtest
+nameSuffix: -rhplatformtest
 
-namespace: platformtest
+namespace: ddis-asteroid--usernaut-rhplatformtest
 
 resources:
   - ../../base

--- a/config/default/overlays/rhplatformtest/patches/manager-deployment-env.yaml
+++ b/config/default/overlays/rhplatformtest/patches/manager-deployment-env.yaml
@@ -10,4 +10,4 @@ spec:
         - name: manager
           env:
             - name: APP_ENV
-              value: platformtest
+              value: rhplatformtest

--- a/config/default/overlays/rhprod/kustomization.yaml
+++ b/config/default/overlays/rhprod/kustomization.yaml
@@ -1,6 +1,6 @@
-nameSuffix: -prod
+nameSuffix: -rhprod
 
-namespace: usernaut
+namespace: ddis-asteroid--usernaut-rhprod
 
 resources:
   - ../../base

--- a/config/default/overlays/rhprod/patches/manager-deployment-env.yaml
+++ b/config/default/overlays/rhprod/patches/manager-deployment-env.yaml
@@ -10,4 +10,4 @@ spec:
         - name: manager
           env:
             - name: APP_ENV
-              value: prod
+              value: rhprod

--- a/config/manifests/overlays/all/kustomization.yaml
+++ b/config/manifests/overlays/all/kustomization.yaml
@@ -3,8 +3,8 @@
 resources:
 - ../../bases
 - ../../../rbac-admin-sa/overlays/all
-- ../../../default/overlays/platformtest
-- ../../../default/overlays/prod
+- ../../../default/overlays/rhplatformtest
+- ../../../default/overlays/rhprod
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.

--- a/config/manifests/overlays/rhplatformtest/kustomization.yaml
+++ b/config/manifests/overlays/rhplatformtest/kustomization.yaml
@@ -2,7 +2,7 @@
 # used to generate the 'manifests/' directory in a bundle.
 resources:
 - ../../bases
-- ../../../default/overlays/prod
+- ../../../default/overlays/rhplatformtest
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.

--- a/config/manifests/overlays/rhprod/kustomization.yaml
+++ b/config/manifests/overlays/rhprod/kustomization.yaml
@@ -2,7 +2,7 @@
 # used to generate the 'manifests/' directory in a bundle.
 resources:
 - ../../bases
-- ../../../default/overlays/platformtest
+- ../../../default/overlays/rhprod
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.

--- a/config/manual-rbac/base/kustomization.yaml
+++ b/config/manual-rbac/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- serviceaccount.yaml
+- secret.yaml

--- a/config/manual-rbac/base/secret.yaml
+++ b/config/manual-rbac/base/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: usernaut-admin-sa-token
+  namespace: ddis-asteroid--usernaut
+  annotations:
+    kubernetes.io/service-account.name: usernaut-admin-sa
+type: kubernetes.io/service-account-token

--- a/config/manual-rbac/base/serviceaccount.yaml
+++ b/config/manual-rbac/base/serviceaccount.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,3 +7,4 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/part-of: usernaut
   name: usernaut-admin-sa
+  namespace: ddis-asteroid--usernaut

--- a/config/manual-rbac/overlays/usernaut-rhplatformtest/admin-rolebinding.yaml
+++ b/config/manual-rbac/overlays/usernaut-rhplatformtest/admin-rolebinding.yaml
@@ -4,14 +4,15 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/instance: usernaut-admin-rolebinding
+    app.kubernetes.io/instance: usernaut-ns-admin-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/part-of: usernaut
-  name: usernaut-admin-rolebinding
+  name: usernaut-namespace-admin-rolebinding
+  namespace: ddis-asteroid--usernaut-rhplatformtest
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: usernaut-admin-role
+  kind: ClusterRole
+  name: admin
 subjects:
 - kind: ServiceAccount
   name: usernaut-admin-sa

--- a/config/manual-rbac/overlays/usernaut-rhplatformtest/kustomization.yaml
+++ b/config/manual-rbac/overlays/usernaut-rhplatformtest/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../../base
+- admin-rolebinding.yaml

--- a/config/manual-rbac/overlays/usernaut-rhprod/admin-rolebinding.yaml
+++ b/config/manual-rbac/overlays/usernaut-rhprod/admin-rolebinding.yaml
@@ -4,14 +4,15 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/instance: usernaut-admin-rolebinding
+    app.kubernetes.io/instance: usernaut-ns-admin-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/part-of: usernaut
-  name: usernaut-admin-rolebinding
+  name: usernaut-namespace-admin-rolebinding
+  namespace: ddis-asteroid--usernaut-rhprod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: usernaut-admin-role
+  kind: ClusterRole
+  name: admin
 subjects:
 - kind: ServiceAccount
   name: usernaut-admin-sa

--- a/config/manual-rbac/overlays/usernaut-rhprod/kustomization.yaml
+++ b/config/manual-rbac/overlays/usernaut-rhprod/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../../base
+- admin-rolebinding.yaml

--- a/config/rbac-admin-sa/base/role.yaml
+++ b/config/rbac-admin-sa/base/role.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: usernaut
   name: usernaut-admin-role
 rules:
-# access to all verbs on the usernaut-* namespace
+# access to all verbs on the ddis-asteroid--usernaut-* namespace
 - apiGroups:
   - ""
   resources:
@@ -18,7 +18,7 @@ rules:
   - "*"
   resourceNames:
   - replace
-# access to all verbs on all custom resources belonging to the usernaut
+# access to all verbs on all custom resources belonging to the operator
 - apiGroups:
   - operator.dataverse.redhat.com
   resources:

--- a/config/rbac-admin-sa/overlays/all/kustomization.yaml
+++ b/config/rbac-admin-sa/overlays/all/kustomization.yaml
@@ -1,13 +1,12 @@
-namespace: usernaut
-
 resources:
-- ../../base
-- serviceaccount.yaml
+  - ../../base
+
+namespace: ddis-asteroid--usernaut-rhprod
 
 patchesJson6902:
-- target:
-    group: rbac.authorization.k8s.io
-    version: v1
-    kind: Role
-    name: usernaut-admin-role
-  path: patches/usernaut-role-patch.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: usernaut-admin-role
+    path: patches/usernaut-admin-role-patch.yaml

--- a/config/rbac-admin-sa/overlays/all/patches/usernaut-admin-role-patch.yaml
+++ b/config/rbac-admin-sa/overlays/all/patches/usernaut-admin-role-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /rules/0/resourceNames
+  value:
+  - ddis-asteroid--usernaut
+  - ddis-asteroid--usernaut-rhplatformtest
+  - ddis-asteroid--usernaut-rhprod

--- a/config/rbac-admin-sa/overlays/platformtest/patches/usernaut-role-patch.yaml
+++ b/config/rbac-admin-sa/overlays/platformtest/patches/usernaut-role-patch.yaml
@@ -1,4 +1,0 @@
-- op: replace
-  path: /rules/0/resourceNames
-  value:
-  - usernaut-platformtest

--- a/config/rbac-admin-sa/overlays/rhplatformtest/kustomization.yaml
+++ b/config/rbac-admin-sa/overlays/rhplatformtest/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
   - ../../base
 
-namespace: usernaut-platformtest
+namespace: ddis-asteroid--usernaut-rhplatformtest
 
 patchesJson6902:
   - target:
@@ -9,4 +9,4 @@ patchesJson6902:
       version: v1
       kind: Role
       name: usernaut-admin-role
-    path: patches/usernaut-role-patch.yaml
+    path: patches/usernaut-admin-role-patch.yaml

--- a/config/rbac-admin-sa/overlays/rhplatformtest/patches/usernaut-admin-role-patch.yaml
+++ b/config/rbac-admin-sa/overlays/rhplatformtest/patches/usernaut-admin-role-patch.yaml
@@ -1,5 +1,4 @@
 - op: replace
   path: /rules/0/resourceNames
   value:
-  - usernaut-prod
-  - usernaut-platformtest
+  - ddis-asteroid--usernaut-rhplatformtest

--- a/config/redis/kustomization.yaml
+++ b/config/redis/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - redis.yaml
+  - service.yaml

--- a/config/redis/redis.yaml
+++ b/config/redis/redis.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: redis
+  name: redis
+  namespace: ddis-asteroid--config
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - image: quay.io/vinamra2807/redis:latest
+        name: redis
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi

--- a/config/redis/service.yaml
+++ b/config/redis/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: ddis-asteroid--config
+spec:
+  ports:
+    - port: 6379
+      protocol: TCP
+      targetPort: 6379
+  selector:
+    run: redis
+status:
+  loadBalancer: {}

--- a/config/samples/v1alpha1_group.yaml
+++ b/config/samples/v1alpha1_group.yaml
@@ -8,8 +8,9 @@ metadata:
 spec:
   group_name: platformadmin-group
   members:
-  - user1
-  - user2
+    users:
+      - user1
+      - user2
   backends:
   - name: fivetran
     type: fivetran

--- a/scripts/configmap.sh
+++ b/scripts/configmap.sh
@@ -1,0 +1,6 @@
+
+NAMESPACE=ddis-asteroid--usernaut-${ENVIRONMENT}
+
+kubectl create cm usernaut-config --from-file=default.yaml=./appconfig/default.yaml \
+--from-file=${ENVIRONMENT}.yaml=./appconfig/${ENVIRONMENT}.yaml -n ${NAMESPACE}
+


### PR DESCRIPTION
- Fixes the RBAC for the SA which can be used to deploy usernaut in a multi-tenant environment
- Fixes the naming across the manifests to keep it consistent and meaningful.