### PR TITLE
Handling async API responses from Snowflake

### DIFF
--- a/pkg/clients/snowflake/teams.go
+++ b/pkg/clients/snowflake/teams.go
@@ -48,14 +48,12 @@ func (c *SnowflakeClient) FetchAllTeams(ctx context.Context) (map[string]structs
 	return teams, nil
 }
 
-// processTeamsPage processes a page of teams and adds them to the result map
 func (c *SnowflakeClient) processTeamsPage(resp []byte, teams map[string]structs.Team) error {
 	var roles []SnowflakeRole
 	if err := json.Unmarshal(resp, &roles); err != nil {
 		return fmt.Errorf("failed to parse roles response: %w", err)
 	}
 
-	// Extract roles from the response
 	for _, role := range roles {
 		team := structs.Team{
 			ID:   strings.ToLower(role.Name),
@@ -74,24 +72,20 @@ func (c *SnowflakeClient) CreateTeam(ctx context.Context, team *structs.Team) (*
 	log.Info("creating team")
 	endpoint := "/api/v2/roles"
 
-	// Create payload for role creation
 	payload := map[string]interface{}{
 		"name": team.Name,
 	}
 
-	resp, status, err := c.makeRequest(ctx, endpoint, http.MethodPost, payload)
+	resp, _, status, err := c.makeRequestWithPolling(ctx, endpoint, http.MethodPost, payload)
 	if err != nil {
 		log.WithError(err).Error("error creating team")
 		return nil, err
 	}
 
-	// Check for successful creation
 	if status != http.StatusOK && status != http.StatusCreated {
 		return nil, fmt.Errorf("failed to create role, status: %s, body: %s", http.StatusText(status), string(resp))
 	}
 
-	// Return the created team using the request data since Snowflake API
-	// returns minimal information in create response
 	createdTeam := &structs.Team{
 		ID:   strings.ToLower(team.Name),
 		Name: strings.ToLower(team.Name),
@@ -130,13 +124,12 @@ func (c *SnowflakeClient) DeleteTeamByID(ctx context.Context, teamID string) err
 	log.Info("deleting team")
 	endpoint := fmt.Sprintf("/api/v2/roles/%s", teamID)
 
-	resp, status, err := c.makeRequest(ctx, endpoint, http.MethodDelete, nil)
+	resp, _, status, err := c.makeRequestWithPolling(ctx, endpoint, http.MethodDelete, nil)
 	if err != nil {
 		log.WithError(err).Error("error deleting team")
 		return fmt.Errorf("failed to delete role: %w", err)
 	}
 
-	// Check for successful deletion
 	if status != http.StatusOK && status != http.StatusNoContent {
 		return fmt.Errorf("failed to delete role, status: %s, body: %s", http.StatusText(status), string(resp))
 	}


### PR DESCRIPTION
# Changes

## 📝 Description
Handling async API responses from Snowflake

### What changed?
Snowflake sends two types of success response code 200 (sync) and 202 (async) for API requests. For requests, that take long time to complete (ex: more than 45secs or so), Snowflake send 202 response code for such requests and we need to poll the results for such api calls using a different endpoint (called Location). Current code was designed to only handle 200 response code. This was working successfully in environments with less number of users and roles, but in environments, where this value is like 8k-10k, it was sending 202 response codes. Our code was not designed to handle this.

In the new version, we added additional logic to handle both response types for all the Snowflake interfaces


### Why is this change needed?
To handle async responses. This is mostly seen when we are trying to fetch all users and roles from Snowflake as volume is high here. but this can happen with any other API too. Hence, the new code implements async handling logic for all the APIs

### Dependencies
- N/A


## ✅ Developer Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added positive and negative tests that prove my fix is effective or that my feature works
- [ ] Relevant documentation (README, tech specs, etc.) has been added or updated
- [ ] All CI/CD checks are passing
