### PR TITLE
Snowflake: Fetch details in case object already present

### DIFF
--- a/pkg/clients/snowflake/teams.go
+++ b/pkg/clients/snowflake/teams.go
@@ -82,6 +82,11 @@ func (c *SnowflakeClient) CreateTeam(ctx context.Context, team *structs.Team) (*
 		return nil, err
 	}
 
+	if status == http.StatusConflict {
+		log.WithField("status", status).Info("team already exists, fetching team details")
+		return c.FetchTeamDetails(ctx, team.Name)
+	}
+
 	if status != http.StatusOK && status != http.StatusCreated {
 		return nil, fmt.Errorf("failed to create role, status: %s, body: %s", http.StatusText(status), string(resp))
 	}

--- a/pkg/clients/snowflake/users.go
+++ b/pkg/clients/snowflake/users.go
@@ -110,6 +110,11 @@ func (c *SnowflakeClient) CreateUser(ctx context.Context, user *structs.User) (*
 		return nil, err
 	}
 
+	if status == http.StatusConflict {
+		log.WithField("status", status).Info("user already exists, fetching user details")
+		return c.FetchUserDetails(ctx, user.UserName)
+	}
+
 	if status != http.StatusOK && status != http.StatusCreated {
 		return nil, fmt.Errorf("failed to create user, status: %s, body: %s", http.StatusText(status), string(resp))
 	}


### PR DESCRIPTION
# Changes

## 📝 Description

### What changed?

Updated CreateUser/CreateTeam function in snowflake client package to call FetchUserDetails/FetchTeamDetails in case server returns 409

### Why is this change needed?

In case of cache miss, controller tries to create a user/team at snowflake
backend which might return in StatusConflict. In order to handle
this issue gracefully, if snowflake returns 409 during create user/team, we
fetch user/team details and return.

### Dependencies

NA
---

## 🧪 Testing

### Test Coverage

NA

### Performance Impact

NA

---

## 🚀 Deployment

### Deploy Steps

NA

### Prerequisites

NA

### Post-Deployment Monitoring

NA

### Rollback Plan

NA

---

## ⚠️ Breaking Changes

<!-- If there are backward incompatible changes, list them here and describe how they're being handled -->
[~] This PR contains breaking changes
[~] Migration guide provided (if applicable)

**Details:**

<!-- If you checked "This PR contains breaking changes", please provide details on the breaking changes and a migration path. -->
- N/A

---

## ⚙️ Configuration Changes

<!-- List any config changes, additions, or modifications -->
- N/A

---

## ✅ Developer Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [~] I have added positive and negative tests that prove my fix is effective or that my feature works
- [~] Relevant documentation (README, tech specs, etc.) has been added or updated
- [X] All CI/CD checks are passing
