### PR TITLE
Batching requests to ldap and rover for larger groups

### DIFF
--- a/api/v1alpha1/group_types.go
+++ b/api/v1alpha1/group_types.go
@@ -64,9 +64,13 @@ type GroupSpec struct {
 	Backends    []Backend    `json:"backends"`
 }
 
+// Members defines how group membership is resolved. When LDAPQuery is set, Users is optional
+// (members can come only from LDAP). When LDAPQuery is omitted, Users must be a non-empty list.
+//
+// +kubebuilder:validation:XValidation:rule="has(self.ldap_query) || (has(self.users) && size(self.users) > 0)",message="users must be a non-empty list when ldap_query is omitted"
 type Members struct {
 	Groups    []string   `json:"groups,omitempty"`
-	Users     []string   `json:"users"`
+	Users     []string   `json:"users,omitempty"`
 	LDAPQuery *LDAPQuery `json:"ldap_query,omitempty"`
 }
 

--- a/config/crd/bases/operator.dataverse.redhat.com_groups.yaml
+++ b/config/crd/bases/operator.dataverse.redhat.com_groups.yaml
@@ -82,6 +82,9 @@ spec:
                   type: object
                 type: array
               members:
+                description: |-
+                  Members defines how group membership is resolved. When LDAPQuery is set, Users is optional
+                  (members can come only from LDAP). When LDAPQuery is omitted, Users must be a non-empty list.
                 properties:
                   groups:
                     items:
@@ -144,9 +147,11 @@ spec:
                     items:
                       type: string
                     type: array
-                required:
-                - users
                 type: object
+                x-kubernetes-validations:
+                - message: users must be a non-empty list when ldap_query is omitted
+                  rule: has(self.ldap_query) || (has(self.users) && size(self.users)
+                    > 0)
             required:
             - backends
             - group_name

--- a/internal/controller/group_controller.go
+++ b/internal/controller/group_controller.go
@@ -169,7 +169,11 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	r.log.Info("Acquired cache lock for entire reconciliation (LDAP + backends)")
 
 	// Step 1: Fetch LDAP data (does NOT update cache indexes)
-	ldapResult := r.fetchLDAPData(ctx, uniqueMembers)
+	ldapResult, err := r.fetchLDAPData(ctx, uniqueMembers)
+	if err != nil {
+		r.log.WithError(err).Error("LDAP bulk fetch failed; skipping backends until retry")
+		return ctrl.Result{}, err
+	}
 
 	// Step 2: Process all backends (cache operations protected by lock)
 	backendErrors := r.processAllBackends(ctx, groupCR, uniqueMembers)
@@ -354,13 +358,15 @@ func extractManagerUIDsFromQuery(query *usernautdevv1alpha1.LDAPQuery) []string 
 	return managerUIDs
 }
 
-// fetchLDAPData fetches LDAP data for all unique members and populates allLdapUserData
-// This function does NOT update any cache indexes - it only fetches data
-// NOTE: This function assumes CacheMutex is already held by the caller
+// fetchLDAPData fetches LDAP data for all unique members and populates allLdapUserData.
+// This function does NOT update any cache indexes - it only fetches data.
+// If the bulk LDAP client returns an error (e.g. server timeout), the entire reconcile
+// should fail so members are not misclassified as missing from LDAP.
+// NOTE: This function assumes CacheMutex is already held by the caller.
 func (r *GroupReconciler) fetchLDAPData(
 	ctx context.Context,
 	uniqueMembers []string,
-) *LDAPFetchResult {
+) (*LDAPFetchResult, error) {
 	// Initialize LDAP user data map
 	r.allLdapUserData = make(map[string]*structs.LDAPUser, len(uniqueMembers))
 
@@ -375,6 +381,7 @@ func (r *GroupReconciler) fetchLDAPData(
 	bulkData, err := r.LdapConn.GetBulkUserLDAPData(ctx, uniqueMembers)
 	if err != nil {
 		r.log.WithError(err).Error("error fetching bulk LDAP data")
+		return nil, fmt.Errorf("get bulk LDAP user data: %w", err)
 	}
 	if bulkData == nil {
 		bulkData = make(map[string]map[string]interface{})
@@ -412,7 +419,7 @@ func (r *GroupReconciler) fetchLDAPData(
 	return &LDAPFetchResult{
 		CurrentMembers: currentMembers,
 		ActiveUserList: activeUserList,
-	}
+	}, nil
 }
 
 // updateCacheIndexes updates all cache indexes after successful backend reconciliation

--- a/internal/controller/group_controller.go
+++ b/internal/controller/group_controller.go
@@ -370,35 +370,38 @@ func (r *GroupReconciler) fetchLDAPData(
 	// Track current valid members (users with valid LDAP data)
 	currentMembers := make([]string, 0, len(uniqueMembers))
 
-	// Process each unique member - fetch LDAP data only
+	r.log.WithField("member_count", len(uniqueMembers)).Info("fetching LDAP data in bulk")
+
+	bulkData, err := r.LdapConn.GetBulkUserLDAPData(ctx, uniqueMembers)
+	if err != nil {
+		r.log.WithError(err).Error("error fetching bulk LDAP data")
+	}
+	if bulkData == nil {
+		bulkData = make(map[string]map[string]interface{})
+	}
+
 	for _, user := range uniqueMembers {
-		ldapUserData, err := r.LdapConn.GetUserLDAPData(ctx, user)
-		if err != nil {
-			r.log.WithError(err).Error("error fetching user data from LDAP")
-			delete(uniqueUIDs, user)
+		userData, ok := bulkData[user]
+		if !ok {
+			r.log.WithField("user", user).Warn("user not found in LDAP, skipping")
 			continue
 		}
 
 		ldapUser := &structs.LDAPUser{}
-		err = utils.MapToStruct(ldapUserData, ldapUser)
-		if err != nil {
-			r.log.WithError(err).Error("error converting LDAP user data to struct")
+		if err := utils.MapToStruct(userData, ldapUser); err != nil {
+			r.log.WithField("user", user).WithError(err).Error("error converting LDAP user data to struct")
 			continue
 		}
 
 		r.allLdapUserData[user] = ldapUser
 
-		// Only add UID if it's not already in the list
 		if !uniqueUIDs[ldapUser.GetUID()] {
 			uniqueUIDs[ldapUser.GetUID()] = true
 		}
 
-		// Track this user as a current member
-		email := ldapUser.GetEmail()
-		currentMembers = append(currentMembers, email)
+		currentMembers = append(currentMembers, ldapUser.GetEmail())
 	}
 
-	// Build list of users who are active in LDAP
 	activeUserList := make([]string, 0, len(uniqueUIDs))
 	for uid, isActive := range uniqueUIDs {
 		if isActive {
@@ -614,7 +617,7 @@ func (r *GroupReconciler) processSingleBackend(ctx context.Context,
 				r.backendLogger.WithError(err).Error("error while adding users to the team")
 				return err
 			}
-			r.backendLogger.WithField("users_to_add", usersToAdd).Info("added users to team successfully")
+			r.backendLogger.WithField("num_users_to_add", len(usersToAdd)).Info("added users to team successfully")
 		}
 
 		// Remove users from team if needed
@@ -624,7 +627,7 @@ func (r *GroupReconciler) processSingleBackend(ctx context.Context,
 				r.backendLogger.WithError(err).Error("error while removing users from the team")
 				return err
 			}
-			r.backendLogger.WithField("users_to_remove", usersToRemove).Info("removed users from team successfully")
+			r.backendLogger.WithField("num_users_to_remove", len(usersToRemove)).Info("removed users from team successfully")
 		}
 	}
 
@@ -894,14 +897,14 @@ func (r *GroupReconciler) createUsersInBackendAndCache(ctx context.Context,
 			r.backendLogger.WithField("user", user).WithError(err).Error("error creating user in backend")
 			return err
 		}
-		r.backendLogger.WithField("user", user).Info("created user in backend successfully")
+		r.backendLogger.WithField("user", user).Debug("created user in backend successfully")
 
 		// Update cache with new user ID
 		if err := r.Store.User.SetBackend(ctx, userDetails.GetEmail(), backendKey, newUser.ID); err != nil {
 			r.backendLogger.Error(err, "error updating user details in cache")
 			return err
 		}
-		r.backendLogger.WithField("user", user).Info("updated user details in cache successfully")
+		r.backendLogger.WithField("user", user).Debug("updated user details in cache successfully")
 	}
 	return nil
 }

--- a/internal/controller/group_controller_test.go
+++ b/internal/controller/group_controller_test.go
@@ -129,6 +129,24 @@ var _ = Describe("Group Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource-group"
 
+		// fetchLDAPData calls GetBulkUserLDAPData once; keys must match spec.members.users.
+		bulkLDAPDataOK := map[string]map[string]interface{}{
+			"test-user-1": {
+				"cn":          "Test",
+				"sn":          "User",
+				"displayName": "Test User",
+				"mail":        "testuser@gmail.com",
+				"uid":         "testuser",
+			},
+			"test-user-2": {
+				"cn":          "Test",
+				"sn":          "User",
+				"displayName": "Test User",
+				"mail":        "testuser2@gmail.com",
+				"uid":         "testuser2",
+			},
+		}
+
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
@@ -186,13 +204,7 @@ var _ = Describe("Group Controller", func() {
 			}
 			controllerReconciler, ldapClient := setupTestReconciler([]config.Backend{fivetranBackend})
 
-			ldapClient.EXPECT().GetUserLDAPData(gomock.Any(), gomock.Any()).Return(map[string]interface{}{
-				"cn":          "Test",
-				"sn":          "User",
-				"displayName": "Test User",
-				"mail":        "testuser@gmail.com",
-				"uid":         "testuser",
-			}, nil).Times(2)
+			ldapClient.EXPECT().GetBulkUserLDAPData(gomock.Any(), gomock.Any()).Return(bulkLDAPDataOK, nil).Times(1)
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -250,13 +262,7 @@ var _ = Describe("Group Controller", func() {
 			}
 			reconciler, ldapClient := setupTestReconciler([]config.Backend{fivetranA, fivetranB})
 
-			ldapClient.EXPECT().GetUserLDAPData(gomock.Any(), gomock.Any()).Return(map[string]interface{}{
-				"cn":          "Test",
-				"sn":          "User",
-				"displayName": "Test User",
-				"mail":        "testuser@gmail.com",
-				"uid":         "testuser",
-			}, nil).Times(2)
+			ldapClient.EXPECT().GetBulkUserLDAPData(gomock.Any(), gomock.Any()).Return(bulkLDAPDataOK, nil).Times(1)
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiNN})
 			Expect(err).To(HaveOccurred())
@@ -330,13 +336,7 @@ var _ = Describe("Group Controller", func() {
 			}
 			reconciler, ldapClient := setupTestReconciler([]config.Backend{gitlabBackend})
 
-			ldapClient.EXPECT().GetUserLDAPData(gomock.Any(), gomock.Any()).Return(map[string]interface{}{
-				"cn":          "CN-test",
-				"sn":          "SN-test",
-				"displayName": "Open Source",
-				"mail":        "opensource@email.com",
-				"uid":         "uid-test",
-			}, nil).Times(2)
+			ldapClient.EXPECT().GetBulkUserLDAPData(gomock.Any(), gomock.Any()).Return(bulkLDAPDataOK, nil).Times(1)
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: gitlabNN})
 			Expect(err).To(HaveOccurred())

--- a/internal/controller/group_members_validation_test.go
+++ b/internal/controller/group_members_validation_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	usernautdevv1alpha1 "github.com/redhat-data-and-ai/usernaut/api/v1alpha1"
+)
+
+// CRD CEL on spec.members (see api/v1alpha1/group_types.go): users must be non-empty when ldap_query is omitted.
+var _ = Describe("Group spec.members validation", func() {
+	ctx := context.Background()
+
+	minimalBackend := []usernautdevv1alpha1.Backend{
+		{Name: "fivetran", Type: "fivetran"},
+	}
+
+	validLDAPQuery := &usernautdevv1alpha1.LDAPQuery{
+		Operator: "and",
+		Filters: []usernautdevv1alpha1.LDAPFilter{
+			{Key: "employeeType", Criteria: "equals", Value: "employee"},
+		},
+	}
+
+	newGroup := func(name string, members usernautdevv1alpha1.Members) *usernautdevv1alpha1.Group {
+		return &usernautdevv1alpha1.Group{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: usernautdevv1alpha1.GroupSpec{
+				GroupName: name,
+				Members:   members,
+				Backends:  minimalBackend,
+			},
+		}
+	}
+
+	expectInvalidMembers := func(err error) {
+		GinkgoHelper()
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected invalid Group (CEL/members): %v", err)
+		msg := err.Error()
+		Expect(strings.Contains(msg, "users must be a non-empty list when ldap_query is omitted") ||
+			strings.Contains(msg, "ldap_query is omitted")).To(BeTrue(), "unexpected error: %v", err)
+	}
+
+	It("rejects members with no ldap_query and empty users list", func() {
+		name := "group-members-reject-empty-users"
+		g := newGroup(name, usernautdevv1alpha1.Members{
+			Users: []string{},
+		})
+		expectInvalidMembers(k8sClient.Create(ctx, g))
+	})
+
+	It("rejects members with no ldap_query and users omitted", func() {
+		name := "group-members-reject-no-users-field"
+		g := newGroup(name, usernautdevv1alpha1.Members{
+			Groups: []string{"some-group"},
+		})
+		expectInvalidMembers(k8sClient.Create(ctx, g))
+	})
+
+	It("accepts ldap_query with no users (query-only membership)", func() {
+		name := "group-members-accept-query-only"
+		g := newGroup(name, usernautdevv1alpha1.Members{
+			LDAPQuery: validLDAPQuery,
+		})
+		Expect(k8sClient.Create(ctx, g)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, g)
+		})
+	})
+
+	It("accepts ldap_query with empty users slice", func() {
+		name := "group-members-accept-query-empty-users"
+		g := newGroup(name, usernautdevv1alpha1.Members{
+			Users:     []string{},
+			LDAPQuery: validLDAPQuery,
+		})
+		Expect(k8sClient.Create(ctx, g)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, g)
+		})
+	})
+
+	It("accepts non-empty users without ldap_query", func() {
+		name := "group-members-accept-users-only"
+		g := newGroup(name, usernautdevv1alpha1.Members{
+			Users: []string{"alice"},
+		})
+		Expect(k8sClient.Create(ctx, g)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, g)
+		})
+	})
+})

--- a/internal/controller/mocks/ldap_mock.go
+++ b/internal/controller/mocks/ldap_mock.go
@@ -117,6 +117,21 @@ func (mr *MockLDAPClientMockRecorder) BuildLDAPQueryFromSpec(ctx, query interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildLDAPQueryFromSpec", reflect.TypeOf((*MockLDAPClient)(nil).BuildLDAPQueryFromSpec), ctx, query)
 }
 
+// GetBulkUserLDAPData mocks base method.
+func (m *MockLDAPClient) GetBulkUserLDAPData(ctx context.Context, userIDs []string) (map[string]map[string]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBulkUserLDAPData", ctx, userIDs)
+	ret0, _ := ret[0].(map[string]map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBulkUserLDAPData indicates an expected call of GetBulkUserLDAPData.
+func (mr *MockLDAPClientMockRecorder) GetBulkUserLDAPData(ctx, userIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBulkUserLDAPData", reflect.TypeOf((*MockLDAPClient)(nil).GetBulkUserLDAPData), ctx, userIDs)
+}
+
 // GetQueryMembers mocks base method.
 func (m *MockLDAPClient) GetQueryMembers(ctx context.Context, query string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/clients/ldap/client.go
+++ b/pkg/clients/ldap/client.go
@@ -37,6 +37,7 @@ type LDAPConn struct {
 
 type LDAPClient interface {
 	GetUserLDAPData(ctx context.Context, userID string) (map[string]interface{}, error)
+	GetBulkUserLDAPData(ctx context.Context, userIDs []string) (map[string]map[string]interface{}, error)
 	GetQueryMembers(ctx context.Context, query string) ([]string, error)
 	BuildLDAPQueryFromSpec(ctx context.Context, query *v1alpha1.LDAPQuery) (string, error)
 	GetUserLDAPDataByEmail(ctx context.Context, email string) (map[string]interface{}, error)

--- a/pkg/clients/ldap/mocks/ldap_mock.go
+++ b/pkg/clients/ldap/mocks/ldap_mock.go
@@ -117,6 +117,21 @@ func (mr *MockLDAPClientMockRecorder) BuildLDAPQueryFromSpec(ctx, query interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildLDAPQueryFromSpec", reflect.TypeOf((*MockLDAPClient)(nil).BuildLDAPQueryFromSpec), ctx, query)
 }
 
+// GetBulkUserLDAPData mocks base method.
+func (m *MockLDAPClient) GetBulkUserLDAPData(ctx context.Context, userIDs []string) (map[string]map[string]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBulkUserLDAPData", ctx, userIDs)
+	ret0, _ := ret[0].(map[string]map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBulkUserLDAPData indicates an expected call of GetBulkUserLDAPData.
+func (mr *MockLDAPClientMockRecorder) GetBulkUserLDAPData(ctx, userIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBulkUserLDAPData", reflect.TypeOf((*MockLDAPClient)(nil).GetBulkUserLDAPData), ctx, userIDs)
+}
+
 // GetQueryMembers mocks base method.
 func (m *MockLDAPClient) GetQueryMembers(ctx context.Context, query string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/clients/ldap/query.go
+++ b/pkg/clients/ldap/query.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (l *LDAPConn) GetQueryMembers(ctx context.Context, query string) ([]string, error) {
+	// Do not call LDAP if the request context is already cancelled or its deadline has passed
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/pkg/clients/ldap/query.go
+++ b/pkg/clients/ldap/query.go
@@ -12,6 +12,9 @@ import (
 )
 
 func (l *LDAPConn) GetQueryMembers(ctx context.Context, query string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	log := logger.Logger(ctx).WithField("query", query)
 	log.Info("fetching query members")
 

--- a/pkg/clients/ldap/query_test.go
+++ b/pkg/clients/ldap/query_test.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"context"
 	"errors"
 
 	"github.com/go-ldap/ldap/v3"
@@ -54,6 +55,24 @@ func (suite *LDAPTestSuite) TestGetQueryMembers() {
 		assertions.Equal(query, capturedReq.Filter)
 		assertions.Equal([]string{"uid"}, capturedReq.Attributes)
 	}
+}
+
+func (suite *LDAPTestSuite) TestGetQueryMembers_ContextCanceled() {
+	assertions := assert.New(suite.T())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ldapConn := &LDAPConn{
+		conn:       suite.ldapClient,
+		baseUserDN: "ou=users,dc=example,dc=com",
+		server:     "ldap://ldap.com:389",
+		attributes: []string{"cn"},
+	}
+
+	resp, err := ldapConn.GetQueryMembers(ctx, "(objectClass=groupOfNames)")
+
+	assertions.ErrorIs(err, context.Canceled)
+	assertions.Nil(resp)
 }
 
 func (suite *LDAPTestSuite) TestGetQueryMembers_NoEntriesFound() {

--- a/pkg/clients/ldap/user.go
+++ b/pkg/clients/ldap/user.go
@@ -10,7 +10,8 @@ import (
 	"github.com/redhat-data-and-ai/usernaut/pkg/logger"
 )
 
-const bulkLDAPBatchSize = 500
+// bulkLDAPBatchSize caps OR-filter batch size
+var bulkLDAPBatchSize = 500
 
 var (
 	ErrNoUserFound = errors.New("no LDAP entries found for user")
@@ -68,6 +69,9 @@ func (l *LDAPConn) executeSearch(ctx context.Context,
 // GetUserLDAPData retrieves user data from LDAP using the userID (username).
 // It constructs a search request with a uid filter and performs a subtree search in baseDN.
 func (l *LDAPConn) GetUserLDAPData(ctx context.Context, userID string) (map[string]interface{}, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	log := logger.Logger(ctx).WithField("userID", userID)
 	log.Debug("fetching user LDAP data")
 
@@ -98,6 +102,8 @@ func (l *LDAPConn) GetUserLDAPData(ctx context.Context, userID string) (map[stri
 // GetBulkUserLDAPData retrieves LDAP data for multiple users in batched OR queries,
 // returning a map keyed by uid. Users not found in LDAP are silently omitted from
 // the result. Batches are capped at bulkLDAPBatchSize to stay within server size limits.
+// If ctx is canceled or times out, the function returns any data fetched so far together
+// with ctx.Err(); it does not start further batches. An in-flight Search is not aborted.
 func (l *LDAPConn) GetBulkUserLDAPData(
 	ctx context.Context,
 	userIDs []string,
@@ -108,12 +114,18 @@ func (l *LDAPConn) GetBulkUserLDAPData(
 	if len(userIDs) == 0 {
 		return result, nil
 	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
 
 	totalBatches := (len(userIDs) + bulkLDAPBatchSize - 1) / bulkLDAPBatchSize
 	log.WithField("total_users", len(userIDs)).WithField("batch_size", bulkLDAPBatchSize).
 		WithField("total_batches", totalBatches).Info("starting bulk LDAP fetch")
 
 	for batchStart := 0; batchStart < len(userIDs); batchStart += bulkLDAPBatchSize {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
 		batchEnd := batchStart + bulkLDAPBatchSize
 		if batchEnd > len(userIDs) {
 			batchEnd = len(userIDs)
@@ -171,6 +183,9 @@ func (l *LDAPConn) GetBulkUserLDAPData(
 // GetUserLDAPDataByEmail retrieves user data from LDAP using the email address.
 // It constructs a search request with a mail filter and performs a subtree search in baseDN.
 func (l *LDAPConn) GetUserLDAPDataByEmail(ctx context.Context, email string) (map[string]interface{}, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	log := logger.Logger(ctx).WithField("email", email)
 	log.Debug("fetching user LDAP data by email")
 

--- a/pkg/clients/ldap/user.go
+++ b/pkg/clients/ldap/user.go
@@ -161,8 +161,15 @@ func (l *LDAPConn) GetBulkUserLDAPData(
 
 		resp, err := conn.Search(searchRequest)
 		if err != nil {
-			log.WithError(err).WithField("batch_start", batchStart).Error("bulk LDAP search failed")
-			return result, err
+			log.WithError(err).
+				WithField("batch_start", batchStart).
+				WithField("batch", fmt.Sprintf("%d/%d", batchNum, totalBatches)).
+				WithField("batch_user_ids", batch).
+				Error("bulk LDAP search failed")
+			return result, fmt.Errorf(
+				"bulk LDAP search failed (batch %d/%d, %d users, start offset %d): %w",
+				batchNum, totalBatches, len(batch), batchStart, err,
+			)
 		}
 
 		log.WithField("batch_start", batchStart).WithField("entries", len(resp.Entries)).

--- a/pkg/clients/ldap/user.go
+++ b/pkg/clients/ldap/user.go
@@ -69,6 +69,7 @@ func (l *LDAPConn) executeSearch(ctx context.Context,
 // GetUserLDAPData retrieves user data from LDAP using the userID (username).
 // It constructs a search request with a uid filter and performs a subtree search in baseDN.
 func (l *LDAPConn) GetUserLDAPData(ctx context.Context, userID string) (map[string]interface{}, error) {
+	// Do not call LDAP if the request context is already cancelled or its deadline has passed
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -114,6 +115,7 @@ func (l *LDAPConn) GetBulkUserLDAPData(
 	if len(userIDs) == 0 {
 		return result, nil
 	}
+	// Do not start a bulk fetch if the request context is already cancelled or its deadline has passed
 	if err := ctx.Err(); err != nil {
 		return result, err
 	}
@@ -123,6 +125,8 @@ func (l *LDAPConn) GetBulkUserLDAPData(
 		WithField("total_batches", totalBatches).Info("starting bulk LDAP fetch")
 
 	for batchStart := 0; batchStart < len(userIDs); batchStart += bulkLDAPBatchSize {
+		// Re-check the context before each batch so we do not start new LDAP work after cancel or
+		// timeout (an in-flight Search is not bound to the context and cannot be aborted here)
 		if err := ctx.Err(); err != nil {
 			return result, err
 		}
@@ -190,6 +194,7 @@ func (l *LDAPConn) GetBulkUserLDAPData(
 // GetUserLDAPDataByEmail retrieves user data from LDAP using the email address.
 // It constructs a search request with a mail filter and performs a subtree search in baseDN.
 func (l *LDAPConn) GetUserLDAPDataByEmail(ctx context.Context, email string) (map[string]interface{}, error) {
+	// Do not call LDAP if the request context is already cancelled or its deadline has passed
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/pkg/clients/ldap/user.go
+++ b/pkg/clients/ldap/user.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/redhat-data-and-ai/usernaut/pkg/logger"
 )
+
+const bulkLDAPBatchSize = 500
 
 var (
 	ErrNoUserFound = errors.New("no LDAP entries found for user")
@@ -90,6 +93,79 @@ func (l *LDAPConn) GetUserLDAPData(ctx context.Context, userID string) (map[stri
 
 	log.Debug("fetched user LDAP data")
 	return userData, nil
+}
+
+// GetBulkUserLDAPData retrieves LDAP data for multiple users in batched OR queries,
+// returning a map keyed by uid. Users not found in LDAP are silently omitted from
+// the result. Batches are capped at bulkLDAPBatchSize to stay within server size limits.
+func (l *LDAPConn) GetBulkUserLDAPData(
+	ctx context.Context,
+	userIDs []string,
+) (map[string]map[string]interface{}, error) {
+	log := logger.Logger(ctx)
+	result := make(map[string]map[string]interface{}, len(userIDs))
+
+	if len(userIDs) == 0 {
+		return result, nil
+	}
+
+	totalBatches := (len(userIDs) + bulkLDAPBatchSize - 1) / bulkLDAPBatchSize
+	log.WithField("total_users", len(userIDs)).WithField("batch_size", bulkLDAPBatchSize).
+		WithField("total_batches", totalBatches).Info("starting bulk LDAP fetch")
+
+	for batchStart := 0; batchStart < len(userIDs); batchStart += bulkLDAPBatchSize {
+		batchEnd := batchStart + bulkLDAPBatchSize
+		if batchEnd > len(userIDs) {
+			batchEnd = len(userIDs)
+		}
+		batch := userIDs[batchStart:batchEnd]
+		batchNum := (batchStart / bulkLDAPBatchSize) + 1
+
+		log.WithField("batch", fmt.Sprintf("%d/%d", batchNum, totalBatches)).
+			WithField("batch_users", len(batch)).Info("processing LDAP batch")
+
+		var uidFilters strings.Builder
+		for _, uid := range batch {
+			fmt.Fprintf(&uidFilters, "(uid=%s)", ldap.EscapeFilter(uid))
+		}
+		filter := fmt.Sprintf("(&(%s)(|%s))", l.userSearchFilter, uidFilters.String())
+
+		searchRequest := ldap.NewSearchRequest(
+			l.baseUserDN,
+			ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+			filter,
+			l.attributes,
+			nil,
+		)
+
+		conn := l.getConn()
+		if conn == nil {
+			return result, errors.New("LDAP connection is nil")
+		}
+
+		if err := conn.UnauthenticatedBind(""); err != nil {
+			return result, fmt.Errorf("failed to bind before bulk search: %w", err)
+		}
+
+		resp, err := conn.Search(searchRequest)
+		if err != nil {
+			log.WithError(err).WithField("batch_start", batchStart).Error("bulk LDAP search failed")
+			return result, err
+		}
+
+		log.WithField("batch_start", batchStart).WithField("entries", len(resp.Entries)).
+			Info("bulk LDAP batch returned")
+
+		for _, entry := range resp.Entries {
+			uid := entry.GetAttributeValue("uid")
+			if uid == "" {
+				continue
+			}
+			result[uid] = l.parseLDAPEntry(entry)
+		}
+	}
+
+	return result, nil
 }
 
 // GetUserLDAPDataByEmail retrieves user data from LDAP using the email address.

--- a/pkg/clients/ldap/user_test.go
+++ b/pkg/clients/ldap/user_test.go
@@ -389,6 +389,88 @@ func (suite *LDAPTestSuite) TestGetUserLDAPDataByEmail_NilConnection() {
 	assertions.Nil(resp)
 }
 
+func (suite *LDAPTestSuite) TestGetUserLDAPData_ContextCanceledBeforeSearch() {
+	assertions := assert.New(suite.T())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ldapConn := &LDAPConn{
+		conn:             suite.ldapClient,
+		userDN:           "uid=%s,ou=users,dc=example,dc=com",
+		baseDN:           "ou=adhoc,ou=managedGroups,dc=example,dc=com",
+		server:           "ldap://ldap.com:389",
+		userSearchFilter: "(objectClass=uid)",
+		attributes:       []string{"mail"},
+	}
+
+	resp, err := ldapConn.GetUserLDAPData(ctx, "testuser")
+
+	assertions.ErrorIs(err, context.Canceled)
+	assertions.Nil(resp)
+}
+
+func (suite *LDAPTestSuite) TestGetBulkUserLDAPData_ContextCanceledBeforeLDAP() {
+	assertions := assert.New(suite.T())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ldapConn := &LDAPConn{
+		conn:             suite.ldapClient,
+		baseUserDN:       "ou=users,dc=example,dc=com",
+		server:           "ldap://ldap.com:389",
+		userSearchFilter: "(objectClass=person)",
+		attributes:       []string{"mail", "uid"},
+	}
+
+	out, err := ldapConn.GetBulkUserLDAPData(ctx, []string{"u1", "u2"})
+
+	assertions.ErrorIs(err, context.Canceled)
+	assertions.Empty(out)
+}
+
+func (suite *LDAPTestSuite) TestGetBulkUserLDAPData_ContextCanceledStopsAfterFirstBatch() {
+	assertions := assert.New(suite.T())
+
+	prev := bulkLDAPBatchSize
+	bulkLDAPBatchSize = 2
+	defer func() { bulkLDAPBatchSize = prev }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	entry := func(uid string) *ldap.Entry {
+		return &ldap.Entry{
+			DN: "uid=" + uid + ",ou=users,dc=example,dc=com",
+			Attributes: []*ldap.EntryAttribute{
+				{Name: "uid", Values: []string{uid}},
+				{Name: "mail", Values: []string{uid + "@example.com"}},
+			},
+		}
+	}
+
+	suite.ldapClient.EXPECT().IsClosing().Return(false).Times(1)
+	suite.ldapClient.EXPECT().UnauthenticatedBind("").Return(nil).Times(1)
+	suite.ldapClient.EXPECT().Search(gomock.Any()).DoAndReturn(
+		func(_ *ldap.SearchRequest) (*ldap.SearchResult, error) {
+			cancel()
+			return &ldap.SearchResult{Entries: []*ldap.Entry{entry("a1")}}, nil
+		},
+	).Times(1)
+
+	ldapConn := &LDAPConn{
+		conn:             suite.ldapClient,
+		baseUserDN:       "ou=users,dc=example,dc=com",
+		server:           "ldap://ldap.com:389",
+		userSearchFilter: "(objectClass=person)",
+		attributes:       []string{"mail", "uid"},
+	}
+
+	out, err := ldapConn.GetBulkUserLDAPData(ctx, []string{"a1", "a2", "b1", "b2"})
+
+	assertions.ErrorIs(err, context.Canceled)
+	assertions.Len(out, 1)
+	assertions.Contains(out, "a1")
+}
+
 func (suite *LDAPTestSuite) TestGetUserLDAPDataByEmail_BindError() {
 	assertions := assert.New(suite.T())
 

--- a/pkg/clients/redhat_rover/team_membership.go
+++ b/pkg/clients/redhat_rover/team_membership.go
@@ -71,6 +71,8 @@ func (rC *RoverClient) FetchTeamMembersByTeamID(ctx context.Context, teamID stri
 	return members, nil
 }
 
+const roverBatchSize = 500
+
 func (rC *RoverClient) modify(
 	ctx context.Context,
 	spanName string,
@@ -81,38 +83,58 @@ func (rC *RoverClient) modify(
 	defer span.Finish()
 	log := logger.Logger(ctx)
 
-	var req MemberModRequest
-	switch action {
-	case "add":
-		log.Info("adding team users to the rover group")
-		req.Additions = make([]Member, 0, len(userIDs))
-		for _, id := range userIDs {
-			req.Additions = append(req.Additions, Member{ID: id, Type: MemberTypeUser})
-		}
-	case "remove":
-		log.Info("removing team users from the rover group")
-		req.Deletions = make([]Member, 0, len(userIDs))
-		for _, id := range userIDs {
-			req.Deletions = append(req.Deletions, Member{ID: id, Type: MemberTypeUser})
-		}
-	default:
+	if action != "add" && action != "remove" {
 		return fmt.Errorf("invalid action:%s", action)
 	}
 
-	_, respCode, err := rC.sendRequest(ctx,
-		rC.url+"/v1/groups/"+teamID+"/membersMod",
-		http.MethodPost,
-		req,
-		headers,
-		spanName)
-	if err != nil {
-		log.WithError(err).Errorf("failed to %s users in rover group", action)
-		return err
-	}
+	totalBatches := (len(userIDs) + roverBatchSize - 1) / roverBatchSize
+	log.WithField("action", action).WithField("total_users", len(userIDs)).
+		WithField("total_batches", totalBatches).
+		Infof("%sing users in rover group (batched)", action)
 
-	if respCode != http.StatusOK {
-		log.Errorf("failed to %s users in rover group", action)
-		return fmt.Errorf("failed to %s users in rover group with response code: %s", action, http.StatusText(respCode))
+	for batchStart := 0; batchStart < len(userIDs); batchStart += roverBatchSize {
+		batchEnd := batchStart + roverBatchSize
+		if batchEnd > len(userIDs) {
+			batchEnd = len(userIDs)
+		}
+		batch := userIDs[batchStart:batchEnd]
+		batchNum := (batchStart / roverBatchSize) + 1
+
+		log.WithField("batch", fmt.Sprintf("%d/%d", batchNum, totalBatches)).
+			WithField("batch_users", len(batch)).
+			Infof("processing rover %s batch", action)
+
+		members := make([]Member, 0, len(batch))
+		for _, id := range batch {
+			members = append(members, Member{ID: id, Type: MemberTypeUser})
+		}
+
+		var req MemberModRequest
+		switch action {
+		case "add":
+			req.Additions = members
+		case "remove":
+			req.Deletions = members
+		}
+
+		_, respCode, err := rC.sendRequest(ctx,
+			rC.url+"/v1/groups/"+teamID+"/membersMod",
+			http.MethodPost,
+			req,
+			headers,
+			spanName)
+		if err != nil {
+			log.WithError(err).Errorf("failed to %s users in rover group (batch %d/%d)", action, batchNum, totalBatches)
+			return err
+		}
+
+		if respCode != http.StatusOK {
+			log.Errorf("failed to %s users in rover group (batch %d/%d)", action, batchNum, totalBatches)
+			return fmt.Errorf("failed to %s users in rover group with response code: %s", action, http.StatusText(respCode))
+		}
+
+		log.WithField("batch", fmt.Sprintf("%d/%d", batchNum, totalBatches)).
+			Infof("rover %s batch completed", action)
 	}
 
 	return nil

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -106,7 +106,7 @@ func (r *Requester) sendRequest(httpClient heimdall.Doer, methodName string,
 		"service": serviceName,
 		"method":  methodName,
 		"url":     r.request.URL.String(),
-	}).Debug("SENDING_HTTP_REQUEST")
+	}).Info("SENDING_HTTP_REQUEST")
 
 	response, err := httpClient.Do(r.request)
 
@@ -114,7 +114,7 @@ func (r *Requester) sendRequest(httpClient heimdall.Doer, methodName string,
 		"service": serviceName,
 		"method":  methodName,
 		"url":     r.request.URL.String(),
-	}).Debug("RECEIVED_HTTP_RESPONSE")
+	}).Info("RECEIVED_HTTP_RESPONSE")
 
 	// Calculate time taken to receive response
 	durationMs := float64(time.Since(start).Nanoseconds() / 1000000)
@@ -124,7 +124,7 @@ func (r *Requester) sendRequest(httpClient heimdall.Doer, methodName string,
 		"method":     methodName,
 		"url":        r.request.URL.String(),
 		"durationMs": durationMs,
-	}).Debug("HTTP_RESPONSE_DURATION")
+	}).Info("HTTP_RESPONSE_DURATION")
 
 	if err != nil {
 		return nil, nil, err

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -106,7 +106,7 @@ func (r *Requester) sendRequest(httpClient heimdall.Doer, methodName string,
 		"service": serviceName,
 		"method":  methodName,
 		"url":     r.request.URL.String(),
-	}).Info("SENDING_HTTP_REQUEST")
+	}).Debug("SENDING_HTTP_REQUEST")
 
 	response, err := httpClient.Do(r.request)
 
@@ -114,7 +114,7 @@ func (r *Requester) sendRequest(httpClient heimdall.Doer, methodName string,
 		"service": serviceName,
 		"method":  methodName,
 		"url":     r.request.URL.String(),
-	}).Info("RECEIVED_HTTP_RESPONSE")
+	}).Debug("RECEIVED_HTTP_RESPONSE")
 
 	// Calculate time taken to receive response
 	durationMs := float64(time.Since(start).Nanoseconds() / 1000000)
@@ -124,7 +124,7 @@ func (r *Requester) sendRequest(httpClient heimdall.Doer, methodName string,
 		"method":     methodName,
 		"url":        r.request.URL.String(),
 		"durationMs": durationMs,
-	}).Info("HTTP_RESPONSE_DURATION")
+	}).Debug("HTTP_RESPONSE_DURATION")
 
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
# Changes

## 📝 Description

### What changed?
Batching requests to ldap and rover for larger groups

### Why is this change needed?
- Querying ldap for every single user is time consuming
- If we make a group modification request to rover with 24000 users, it throws Internal Server error

### Dependencies
<!-- List any dependencies required for this change -->
- N/A

---

## 🧪 Testing

### Test Coverage
<!-- Describe the tests you ran and how your change affects other areas -->

### Performance Impact
<!-- Describe any performance impact (positive or negative) and how you measured it -->
- N/A

---

## 🚀 Deployment

### Deploy Steps
<!-- Outline steps to deploy this to production -->
1. N/A

### Prerequisites
<!-- List any prerequisites before deployment -->
- N/A

### Post-Deployment Monitoring
<!-- What should be monitored after deployment? -->
- N/A

### Rollback Plan
<!-- How to rollback if issues arise -->
- N/A

---

## ⚠️ Breaking Changes

<!-- If there are backward incompatible changes, list them here and describe how they're being handled -->
- [ ] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

**Details:**

<!-- If you checked "This PR contains breaking changes", please provide details on the breaking changes and a migration path. -->
- N/A

---

## ⚙️ Configuration Changes

<!-- List any config changes, additions, or modifications -->
- N/A

---

## ✅ Developer Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added positive and negative tests that prove my fix is effective or that my feature works
- [ ] Relevant documentation (README, tech specs, etc.) has been added or updated
- [x] All CI/CD checks are passing
