### PR TITLE
fix(httpapi): validate email format in GetUserGroups handler

### DIFF
--- a/internal/httpapi/handlers/handlers.go
+++ b/internal/httpapi/handlers/handlers.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"net/http"
+	"regexp"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -26,6 +27,10 @@ import (
 	"github.com/redhat-data-and-ai/usernaut/pkg/config"
 	"github.com/redhat-data-and-ai/usernaut/pkg/store"
 )
+
+// emailRegex provides a permissive RFC 5322-style email check sufficient to reject
+// inputs that could be abused as Redis pattern-matching probes via the user store.
+var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
 
 type Handlers struct {
 	config *config.AppConfig
@@ -77,6 +82,11 @@ func (h *Handlers) GetUserGroups(c *gin.Context) {
 	email := c.Param("email")
 	if email == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "email parameter is required"})
+		return
+	}
+
+	if !emailRegex.MatchString(email) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email format"})
 		return
 	}
 

--- a/internal/httpapi/handlers/handlers_test.go
+++ b/internal/httpapi/handlers/handlers_test.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmailRegexAcceptsValidEmail(t *testing.T) {
+	assert.True(t, emailRegex.MatchString("user.name+tag@example.com"))
+}
+
+func TestGetUserGroupsValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		email        string
+		expectedBody string
+	}{
+		{
+			name:         "empty email returns required error",
+			email:        "",
+			expectedBody: `{"error":"email parameter is required"}`,
+		},
+		{
+			name:         "not an email returns invalid format",
+			email:        "not-an-email",
+			expectedBody: `{"error":"invalid email format"}`,
+		},
+		{
+			name:         "missing local part returns invalid format",
+			email:        "@nodomain",
+			expectedBody: `{"error":"invalid email format"}`,
+		},
+		{
+			name:         "missing domain returns invalid format",
+			email:        "foo@",
+			expectedBody: `{"error":"invalid email format"}`,
+		},
+		{
+			name:         "plain value returns invalid format",
+			email:        "plain",
+			expectedBody: `{"error":"invalid email format"}`,
+		},
+		{
+			name:         "redis pattern probe returns invalid format",
+			email:        "*@*",
+			expectedBody: `{"error":"invalid email format"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/user/"+tt.email+"/groups", nil)
+			c.Params = gin.Params{{Key: "email", Value: tt.email}}
+
+			h := &Handlers{}
+			h.GetUserGroups(c)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.JSONEq(t, tt.expectedBody, w.Body.String())
+		})
+	}
+}


### PR DESCRIPTION
# Changes

## 📝 Description

### What changed?
`GetUserGroups` now rejects requests whose `email` URL parameter does not match a permissive RFC 5322-style format. Empty-string handling is unchanged; the new check runs after it.

### Why is this change needed?
The handler previously forwarded the parameter directly to `store.UserGroups.GetGroups()` after only checking for an empty string. The Redis-backed cache layer treats some inputs as pattern probes, so unvalidated input could be used to enumerate or otherwise abuse the store. Tracked in #287; flagged with `security-fix-required` and acknowledged by @vinamra28.

### Dependencies
- N/A (`regexp` is stdlib, already used elsewhere in the project).

---

## 🧪 Testing

### Test Coverage
- New `internal/httpapi/handlers/handlers_test.go` covers the regex itself and the handler's 400 path for empty, malformed, and pattern-probe inputs (`""`, `"not-an-email"`, `"@nodomain"`, `"foo@"`, `"plain"`, `"*@*"`).
- `go fmt`, `go vet`, `go build`, and `go test ./internal/httpapi/handlers/...` all pass locally.
- Happy-path 200 case is intentionally not added here; it requires a real or mocked store and felt out of scope for the validation fix. Happy to extend if the maintainers prefer.

### Performance Impact
- One pre-compiled regex match per request to this endpoint. Negligible.

---

## 🚀 Deployment

### Deploy Steps
1. N/A (no schema or config change).

### Prerequisites
- N/A.

### Post-Deployment Monitoring
- Watch for any unexpected 400s on `/users/:email/groups` from clients that may have been relying on the lack of validation.

### Rollback Plan
- Standard revert.

---

## ⚠️ Breaking Changes

- [ ] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

**Details:**

A request that previously got `500` (or arbitrary store behavior) for an unparseable email will now get `400 invalid email format`. Real callers using actual email addresses are unaffected.

---

## ⚙️ Configuration Changes

- N/A.

---

## ✅ Developer Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added positive and negative tests that prove my fix is effective or that my feature works
- [x] Relevant documentation (README, tech specs, etc.) has been added or updated
- [x] All CI/CD checks are passing

Closes #287