### PR TITLE
chore: update Redis official image to 8.6.2

### DIFF
--- a/config/redis/redis.yaml
+++ b/config/redis/redis.yaml
@@ -16,7 +16,7 @@ spec:
         app: redis
     spec:
       containers:
-      - image: docker.io/library/redis:8.6.2  
+      - image: docker.io/library/redis:8.6.2
         name: redis
         ports:
         - containerPort: 6379

--- a/config/redis/redis.yaml
+++ b/config/redis/redis.yaml
@@ -16,7 +16,7 @@ spec:
         app: redis
     spec:
       containers:
-      - image: quay.io/vinamra2807/redis:latest
+      - image: docker.io/library/redis:8.6.2  
         name: redis
         ports:
         - containerPort: 6379


### PR DESCRIPTION
# Changes

## 📝 Description

### What changed?
- I updated the current Redis image to the official redis:8.6.2 tag to ensure we are using a stable, up-to-date, and secure version.

### Why is this change needed?
 - This change is necessary to improve security, as older image versions may contain vulnerabilities.

- Related Issue: Closes https://github.com/redhat-data-and-ai/usernaut/issues/293

### Dependencies
- N/A

---

## 🧪 Testing

### Test Coverage
- Verified locally by pulling the redis:8.6.2 image successfully.

### Performance Impact
- N/A

---

## 🚀 Deployment

### Deploy Steps
1. Deploy the updated image via the standard CI/CD pipeline.

### Prerequisites
- Monitor for any potential data compatibility issues if the Redis version jump is significant.

### Post-Deployment Monitoring
- Verify that the Redis service starts correctly and all existing data remains accessible.

### Rollback Plan
- Revert the Dockerfile image tag to the previous version and redeploy.

---

## ⚠️ Breaking Changes

<!-- If there are backward incompatible changes, list them here and describe how they're being handled -->
- [ ] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

**Details:**

<!-- If you checked "This PR contains breaking changes", please provide details on the breaking changes and a migration path. -->
- N/A

---

## ⚙️ Configuration Changes

<!-- List any config changes, additions, or modifications -->
- N/A

---

## ✅ Developer Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added positive and negative tests that prove my fix is effective or that my feature works
- [x] Relevant documentation (README, tech specs, etc.) has been added or updated
- [x] All CI/CD checks are passing
