### PR TITLE
fix: guard LDAP connection reconnect with a mutex to remove data race

### DIFF
--- a/pkg/clients/ldap/client.go
+++ b/pkg/clients/ldap/client.go
@@ -36,8 +36,9 @@ var dialLDAP = func(server string) (closeableLDAPConnClient, error) {
 }
 
 type LDAPConn struct {
-	mu               sync.Mutex
+	mu               sync.RWMutex
 	conn             LDAPConnClient
+	connGeneration   uint64
 	userDN           string
 	baseDN           string
 	baseUserDN       string
@@ -81,10 +82,23 @@ func InitLdap(ldapConfig LDAP) (LDAPClient, error) {
 
 // getConn returns the underlying LDAP connection.
 func (l *LDAPConn) getConn() LDAPConnClient {
+	l.mu.RLock()
+	conn := l.conn
+	connGeneration := l.connGeneration
+	if conn != nil && !conn.IsClosing() {
+		l.mu.RUnlock()
+		return conn
+	}
+	l.mu.RUnlock()
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.conn != nil && l.conn.IsClosing() {
+	if l.connGeneration != connGeneration {
+		return l.conn
+	}
+
+	if l.conn != nil {
 		newConn, err := dialLDAP(l.server)
 		if err != nil {
 			// Log the error and return the existing connection (or nil if no valid connection exists)
@@ -99,6 +113,7 @@ func (l *LDAPConn) getConn() LDAPConnClient {
 			return nil
 		}
 		l.conn = newConn
+		l.connGeneration++
 	}
 
 	return l.conn

--- a/pkg/clients/ldap/client.go
+++ b/pkg/clients/ldap/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	ldapv3 "github.com/go-ldap/ldap/v3"
@@ -25,7 +26,17 @@ type LDAPConnClient interface {
 	UnauthenticatedBind(username string) error
 }
 
+type closeableLDAPConnClient interface {
+	LDAPConnClient
+	Close() error
+}
+
+var dialLDAP = func(server string) (closeableLDAPConnClient, error) {
+	return ldapv3.DialURL(server, ldapv3.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}))
+}
+
 type LDAPConn struct {
+	mu               sync.Mutex
 	conn             LDAPConnClient
 	userDN           string
 	baseDN           string
@@ -45,7 +56,7 @@ type LDAPClient interface {
 
 // InitLdap initializes a connection to the LDAP server using the provided configuration.
 func InitLdap(ldapConfig LDAP) (LDAPClient, error) {
-	ldapConn, err := ldapv3.DialURL(ldapConfig.Server, ldapv3.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}))
+	ldapConn, err := dialLDAP(ldapConfig.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -70,8 +81,11 @@ func InitLdap(ldapConfig LDAP) (LDAPClient, error) {
 
 // getConn returns the underlying LDAP connection.
 func (l *LDAPConn) getConn() LDAPConnClient {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	if l.conn != nil && l.conn.IsClosing() {
-		newConn, err := ldapv3.DialURL(l.server, ldapv3.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}))
+		newConn, err := dialLDAP(l.server)
 		if err != nil {
 			// Log the error and return the existing connection (or nil if no valid connection exists)
 			fmt.Printf("Failed to re-establish LDAP connection: %v\n", err)

--- a/pkg/clients/ldap/client_test.go
+++ b/pkg/clients/ldap/client_test.go
@@ -1,11 +1,15 @@
 package ldap
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	ldapv3 "github.com/go-ldap/ldap/v3"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,6 +55,74 @@ func TestInitLdap_Success(t *testing.T) {
 	}
 }
 
+func TestGetLdapConnection_ConcurrentReconnect(t *testing.T) {
+	originalDialLDAP := dialLDAP
+	t.Cleanup(func() {
+		dialLDAP = originalDialLDAP
+	})
+
+	initialConn := newTestLDAPConn(true)
+	reconnectedConn := newTestLDAPConn(false)
+	var dialCount atomic.Int32
+
+	dialLDAP = func(server string) (closeableLDAPConnClient, error) {
+		dialCount.Add(1)
+		return reconnectedConn, nil
+	}
+
+	ldapConn := &LDAPConn{
+		conn:   initialConn,
+		server: "ldap://ldap.com:389",
+	}
+
+	const goroutines = 50
+	start := make(chan struct{})
+	results := make(chan LDAPConnClient, goroutines)
+	var wg sync.WaitGroup
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			results <- ldapConn.getConn()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	for conn := range results {
+		assert.Same(t, reconnectedConn, conn, "Expected every caller to receive the reconnected LDAP connection")
+	}
+	assert.Equal(t, int32(1), dialCount.Load(), "Expected exactly one reconnect")
+	assert.Equal(t, int32(1), reconnectedConn.bindCount.Load(), "Expected exactly one bind on the reconnected connection")
+	assert.Same(t, reconnectedConn, ldapConn.conn, "Expected LDAPConn to store the reconnected connection")
+}
+
+func TestGetLdapConnection_ReconnectFailureKeepsExistingConnection(t *testing.T) {
+	originalDialLDAP := dialLDAP
+	t.Cleanup(func() {
+		dialLDAP = originalDialLDAP
+	})
+
+	initialConn := newTestLDAPConn(true)
+	dialLDAP = func(server string) (closeableLDAPConnClient, error) {
+		return nil, errors.New("dial failed")
+	}
+
+	ldapConn := &LDAPConn{
+		conn:   initialConn,
+		server: "ldap://ldap.com:389",
+	}
+
+	conn := ldapConn.getConn()
+
+	assert.Nil(t, conn, "Expected nil when reconnect dial fails")
+	assert.Same(t, initialConn, ldapConn.conn, "Expected failed reconnect to leave the existing connection unchanged")
+}
+
 // startMockLDAPServer starts a simple mock LDAP server for testing purposes.
 func startMockLDAPServer(t *testing.T) (addr string, stop func()) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -83,4 +155,34 @@ func startMockLDAPServer(t *testing.T) (addr string, stop func()) {
 		close(done)
 		_ = ln.Close()
 	}
+}
+
+type testLDAPConn struct {
+	closing    atomic.Bool
+	bindCount  atomic.Int32
+	closeCount atomic.Int32
+}
+
+func newTestLDAPConn(closing bool) *testLDAPConn {
+	conn := &testLDAPConn{}
+	conn.closing.Store(closing)
+	return conn
+}
+
+func (c *testLDAPConn) IsClosing() bool {
+	return c.closing.Load()
+}
+
+func (c *testLDAPConn) Search(*ldapv3.SearchRequest) (*ldapv3.SearchResult, error) {
+	return &ldapv3.SearchResult{}, nil
+}
+
+func (c *testLDAPConn) UnauthenticatedBind(username string) error {
+	c.bindCount.Add(1)
+	return nil
+}
+
+func (c *testLDAPConn) Close() error {
+	c.closeCount.Add(1)
+	return nil
 }


### PR DESCRIPTION
# Changes

## 📝 Description

### What changed?
`getConn()` in `pkg/clients/ldap/client.go` now takes a `sync.Mutex` before it checks `IsClosing()`, reconnects, and writes `l.conn`. Previously these steps ran without synchronization, so two goroutines could both reconnect and write `l.conn` at the same time. A new `mu sync.Mutex` field guards every read and write of `l.conn`.

### Why is this change needed?
When the reconciler, the offboarding job, and LDAP query resolution call `getConn()` concurrently while the connection is closing, each goroutine sees `IsClosing()` true and dials a new connection. That leaks all but one of the new connections and races on the unsynchronized `l.conn = newConn` write. This fixes #277.

### Dependencies
- N/A

---

## 🧪 Testing

### Test Coverage
Added two tests in `pkg/clients/ldap/client_test.go`:
- `TestGetLdapConnection_ConcurrentReconnect`: 50 goroutines call `getConn()` at once on a closing connection and assert exactly one reconnect, one bind, and a single shared `l.conn`.
- `TestGetLdapConnection_ReconnectFailureKeepsExistingConnection`: when the dial fails, `getConn()` returns nil and leaves the existing `l.conn` untouched.

Commands run:
- `go build ./...` passed.
- `go test -race ./pkg/clients/ldap/...` passed.

The reconnect dial is now reached through a `dialLDAP` package variable so the concurrency test can inject a stub without a live LDAP server. Real behavior is unchanged: it dials the same URL with the same 5s timeout.

### Performance Impact
- N/A. The mutex is held only across the closing-check and reconnect on a single connection object; the common healthy-connection path takes and releases the lock once with no contention.

---

## 🚀 Deployment

### Deploy Steps
1. N/A

### Prerequisites
- N/A

### Post-Deployment Monitoring
- N/A

### Rollback Plan
- N/A

---

## ⚠️ Breaking Changes

- [ ] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

**Details:**

- N/A

---

## ⚙️ Configuration Changes

- N/A

---

## ✅ Developer Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added positive and negative tests that prove my fix is effective or that my feature works
- [ ] Relevant documentation (README, tech specs, etc.) has been added or updated
- [x] All CI/CD checks are passing

Fixes #277


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LDAP connection stability during concurrent reconnects.
  * Prevented stale reconnect attempts from replacing healthy connections.
  * Preserved existing connections when reconnection attempts fail.

* **Tests**
  * Added coverage for concurrent reconnect handling and connection replacement.
  * Added validation that failed reconnects retain the current connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->