### PR TITLE
fix: return errors instead of panicking in config file substitution

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -115,7 +115,8 @@ func TestFileSubstitution(t *testing.T) {
 	fileConfig.Secret = "file|" + tmpfile.Name()
 
 	// Substitute
-	SubstituteConfigValues(reflect.ValueOf(&fileConfig))
+	err = SubstituteConfigValues(reflect.ValueOf(&fileConfig))
+	assert.Nil(t, err)
 
 	assert.Equal(t, secretValue, fileConfig.Secret)
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -105,23 +105,21 @@ func (c *Config) Load(env string, config interface{}) error {
 	if err := c.loadByConfigName(env, config); err != nil {
 		return err
 	}
-	SubstituteConfigValues(reflect.ValueOf(config))
-	return nil
+	return SubstituteConfigValues(reflect.ValueOf(config))
 }
 
 // SubstituteConfigValues recursively walks through the config struct and replaces
 // string values of the form 'env|VAR' or 'file|/path' with the corresponding value.
-func SubstituteConfigValues(v reflect.Value) {
+func SubstituteConfigValues(v reflect.Value) error {
 	if !v.IsValid() {
-		return
+		return nil
 	}
 	// If it's a pointer, resolve it
 	if v.Kind() == reflect.Ptr {
 		if v.IsNil() {
-			return
+			return nil
 		}
-		SubstituteConfigValues(v.Elem())
-		return
+		return SubstituteConfigValues(v.Elem())
 	}
 	// If it's a struct, process its fields
 	if v.Kind() == reflect.Struct {
@@ -130,10 +128,12 @@ func SubstituteConfigValues(v reflect.Value) {
 			if field.CanSet() || field.Kind() == reflect.Ptr ||
 				field.Kind() == reflect.Struct || field.Kind() == reflect.Map ||
 				field.Kind() == reflect.Slice {
-				SubstituteConfigValues(field)
+				if err := SubstituteConfigValues(field); err != nil {
+					return err
+				}
 			}
 		}
-		return
+		return nil
 	}
 	// If it's a map, process its values
 	if v.Kind() == reflect.Map {
@@ -144,44 +144,58 @@ func SubstituteConfigValues(v reflect.Value) {
 			}
 			// Only settable if map value is addressable, so we replace by setting
 			if val.Kind() == reflect.String {
-				newVal := reflect.ValueOf(substituteString(val.String()))
+				substituted, err := substituteString(val.String())
+				if err != nil {
+					return err
+				}
+				newVal := reflect.ValueOf(substituted)
 				v.SetMapIndex(key, newVal)
 			} else {
 				// Recursively process nested maps/structs
 				copyVal := reflect.New(val.Type()).Elem()
 				copyVal.Set(val)
-				SubstituteConfigValues(copyVal)
+				if err := SubstituteConfigValues(copyVal); err != nil {
+					return err
+				}
 				v.SetMapIndex(key, copyVal)
 			}
 		}
-		return
+		return nil
 	}
 	// If it's a slice or array, process its elements
 	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
 		for i := 0; i < v.Len(); i++ {
-			SubstituteConfigValues(v.Index(i))
+			if err := SubstituteConfigValues(v.Index(i)); err != nil {
+				return err
+			}
 		}
-		return
+		return nil
 	}
 	// If it's a string, substitute if needed
 	if v.Kind() == reflect.String && v.CanSet() {
-		v.SetString(substituteString(v.String()))
+		substituted, err := substituteString(v.String())
+		if err != nil {
+			return err
+		}
+		v.SetString(substituted)
 	}
+	return nil
 }
 
 // substituteString replaces 'env|VAR' and 'file|/path' patterns with their values
-func substituteString(s string) string {
+func substituteString(s string) (string, error) {
 	if len(s) > len(EnvPrefix) && s[:len(EnvPrefix)] == EnvPrefix {
-		return os.Getenv(s[len(EnvPrefix):])
+		return os.Getenv(s[len(EnvPrefix):]), nil
 	}
 	if len(s) > len(FilePrefix) && s[:len(FilePrefix)] == FilePrefix {
-		b, err := os.ReadFile(s[len(FilePrefix):])
+		configFilePath := s[len(FilePrefix):]
+		b, err := os.ReadFile(configFilePath)
 		if err != nil {
-			panic(fmt.Sprintf("ERROR: %v", err))
+			return "", fmt.Errorf("failed to read config file %s: %w", configFilePath, err)
 		}
-		return strings.TrimSpace(string(b))
+		return strings.TrimSpace(string(b)), nil
 	}
-	return s
+	return s, nil
 }
 
 // loadByConfigName reads configuration from file and unmarshalls into config.

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubstituteStringFromFile(t *testing.T) {
+	secretFile := filepath.Join(t.TempDir(), "secret.txt")
+	require.NoError(t, os.WriteFile(secretFile, []byte("secret-value\n"), 0600))
+
+	value, err := substituteString(FilePrefix + secretFile)
+
+	require.NoError(t, err)
+	assert.Equal(t, "secret-value", value)
+}
+
+func TestSubstituteStringFromEnv(t *testing.T) {
+	t.Setenv("CONFIG_SECRET", "env-value")
+
+	value, err := substituteString(EnvPrefix + "CONFIG_SECRET")
+
+	require.NoError(t, err)
+	assert.Equal(t, "env-value", value)
+}
+
+func TestSubstituteStringPlainString(t *testing.T) {
+	value, err := substituteString("plain-value")
+
+	require.NoError(t, err)
+	assert.Equal(t, "plain-value", value)
+}
+
+func TestSubstituteStringMissingFileReturnsError(t *testing.T) {
+	missingFile := filepath.Join(t.TempDir(), "missing.txt")
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = substituteString(FilePrefix + missingFile)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read config file "+missingFile)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestLoadReturnsFileSubstitutionError(t *testing.T) {
+	configDir := t.TempDir()
+	missingFile := filepath.Join(configDir, "missing.txt")
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "default.yaml"), []byte("secret: default\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "dev.yaml"), []byte("secret: \"file|"+missingFile+"\"\n"), 0600))
+
+	var loaded struct {
+		Secret string
+	}
+	var err error
+	require.NotPanics(t, func() {
+		err = NewConfig(NewOptions("yaml", configDir, "default")).Load("dev", &loaded)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read config file "+missingFile)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -68,7 +68,11 @@ func TestLoadReturnsFileSubstitutionError(t *testing.T) {
 	configDir := t.TempDir()
 	missingFile := filepath.Join(configDir, "missing.txt")
 	require.NoError(t, os.WriteFile(filepath.Join(configDir, "default.yaml"), []byte("secret: default\n"), 0600))
-	require.NoError(t, os.WriteFile(filepath.Join(configDir, "dev.yaml"), []byte("secret: \"file|"+missingFile+"\"\n"), 0600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configDir, "dev.yaml"),
+		[]byte("secret: \"file|"+missingFile+"\"\n"),
+		0600,
+	))
 
 	var loaded struct {
 		Secret string


### PR DESCRIPTION
# Changes

## 📝 Description

### What changed?
`substituteString` in `pkg/config/loader.go` previously called `panic()` when `os.ReadFile` failed for a `file|` substitution path. It now returns a wrapped error (`failed to read config file <path>: <cause>`). `SubstituteConfigValues` returns `error` and propagates the first failure up through `(*Config).Load`, whose signature already returns `error`. The `env|` substitution and plain-string handling are unchanged.

### Why is this change needed?
If a Kubernetes secret volume mount is missing or a configured file path is wrong, the operator crashes with no recovery path. Returning an error lets the caller handle the failure instead of taking down the process. Fixes #276.

### Dependencies
- N/A

---

## 🧪 Testing

### Test Coverage
Added `pkg/config/loader_test.go` covering: reading a valid `file|` path, an `env|` value, a plain string, a missing `file|` path returning an error without panicking, and `Load` surfacing the file error. Updated the existing `TestFileSubstitution` to the new `SubstituteConfigValues` return signature.

Ran `go build ./...` (passes) and `go test -count=1 ./pkg/config/...` (11 tests pass).

### Performance Impact
- N/A

---

## 🚀 Deployment

### Deploy Steps
1. N/A

### Prerequisites
- N/A

### Post-Deployment Monitoring
- N/A

### Rollback Plan
- N/A

---

## ⚠️ Breaking Changes

- [x] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

**Details:**

The exported `SubstituteConfigValues` signature changes from `func(reflect.Value)` to `func(reflect.Value) error`. All in-tree callers are updated. External callers, if any, need to handle the returned error.

---

## ⚙️ Configuration Changes

- N/A

---

## ✅ Developer Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added positive and negative tests that prove my fix is effective or that my feature works
- [ ] Relevant documentation (README, tech specs, etc.) has been added or updated
- [x] All CI/CD checks are passing
