### PR TITLE
feat: add memberOf as supported ldap_query filter key

### DIFF
--- a/api/v1alpha1/group_types.go
+++ b/api/v1alpha1/group_types.go
@@ -37,7 +37,7 @@ type Backend struct {
 }
 
 type LDAPFilter struct {
-	// +kubebuilder:validation:Enum=givenName;displayName;rhatJobTitle;title;employeeType;manager;rhatCostCenter;rhatCostCenterDesc;rhatGeo;co;st;rhatLocation;rhatOfficeLocation;rhatOfficeFloor;roomNumber
+	// +kubebuilder:validation:Enum=givenName;displayName;rhatJobTitle;title;employeeType;manager;rhatCostCenter;rhatCostCenterDesc;rhatGeo;co;st;rhatLocation;rhatOfficeLocation;rhatOfficeFloor;roomNumber;memberOf
 	Key string `json:"key"`
 	// +kubebuilder:validation:Enum=equals;contains;not
 	Criteria string `json:"criteria"`

--- a/config/samples/v1alpha1_group_querybased.yaml
+++ b/config/samples/v1alpha1_group_querybased.yaml
@@ -14,13 +14,18 @@ spec:
         include_indirect_reports: true
         include_manager: true
       operator: and
-      filters:  # key: LDAP attribute (e.g. manager, title, givenName, employeeType, rhatGeo, co, st). See DEVELOPMENT.md for full list.
+      filters:  # key: LDAP attribute (e.g. manager, title, givenName, employeeType, rhatGeo, co, st, memberOf). See DEVELOPMENT.md for full list.
         - key: manager
           criteria: equals
           value: pbhattac  # user ID only (expanded to uid=pbhattac,<baseUserDN>)
         - key: co
           criteria: equals
           value: "IND"
+        # memberOf derives membership from an existing LDAP/Rover group.
+        # value is expanded to cn=<value>,<baseDN>.
+        # - key: memberOf
+        #   criteria: equals
+        #   value: my-rover-group
     users:
       - subhatta
       - arijroy

--- a/pkg/clients/ldap/query.go
+++ b/pkg/clients/ldap/query.go
@@ -86,7 +86,7 @@ func (l *LDAPConn) BuildLDAPQueryFromSpec(ctx context.Context, query *v1alpha1.L
 	if len(query.Filters) == 0 {
 		return "", errors.New("filters are empty")
 	}
-	filters, err := buildFiltersFromSpec(query.Filters, l.baseUserDN)
+	filters, err := buildFiltersFromSpec(query.Filters, l.baseUserDN, l.baseDN)
 	if err != nil {
 		return "", err
 	}
@@ -102,10 +102,10 @@ func (l *LDAPConn) BuildLDAPQueryFromSpec(ctx context.Context, query *v1alpha1.L
 	}
 }
 
-func buildFiltersFromSpec(filters []v1alpha1.LDAPFilter, baseUserDN string) ([]string, error) {
+func buildFiltersFromSpec(filters []v1alpha1.LDAPFilter, baseUserDN, baseDN string) ([]string, error) {
 	results := make([]string, 0, len(filters))
 	for _, filter := range filters {
-		result, err := buildFilterFromSpec(filter, baseUserDN)
+		result, err := buildFilterFromSpec(filter, baseUserDN, baseDN)
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +114,7 @@ func buildFiltersFromSpec(filters []v1alpha1.LDAPFilter, baseUserDN string) ([]s
 	return results, nil
 }
 
-func buildFilterFromSpec(filter v1alpha1.LDAPFilter, baseUserDN string) (string, error) {
+func buildFilterFromSpec(filter v1alpha1.LDAPFilter, baseUserDN, baseDN string) (string, error) {
 	op := strings.ToLower(strings.TrimSpace(filter.Criteria))
 
 	if baseUserDN == "" {
@@ -137,6 +137,13 @@ func buildFilterFromSpec(filter v1alpha1.LDAPFilter, baseUserDN string) (string,
 
 	if strings.EqualFold(key, "manager") {
 		value = "uid=" + value + "," + baseUserDN
+	}
+
+	if strings.EqualFold(key, "memberOf") {
+		if baseDN == "" {
+			return "", errors.New("base DN is empty; required for memberOf expansion")
+		}
+		value = "cn=" + value + "," + baseDN
 	}
 
 	switch op {

--- a/pkg/clients/ldap/query_test.go
+++ b/pkg/clients/ldap/query_test.go
@@ -285,3 +285,116 @@ func (suite *LDAPTestSuite) TestBuildLDAPQueryFromSpec_MixOperator() {
 	assertions.NoError(err)
 	assertions.Equal("(&(manager=uid=ticramer,ou=users,dc=redhat,dc=com)(!(employeeType=external employee)))", filter)
 }
+
+func (suite *LDAPTestSuite) TestBuildLDAPQueryFromSpec_MemberOfEquals() {
+	assertions := assert.New(suite.T())
+
+	ldapConn := &LDAPConn{
+		baseUserDN: "ou=users,dc=redhat,dc=com",
+		baseDN:     "ou=adhoc,ou=managedGroups,dc=redhat,dc=com",
+	}
+
+	query := &v1alpha1.LDAPQuery{
+		Operator: "and",
+		Filters: []v1alpha1.LDAPFilter{
+			{
+				Key:      "memberOf",
+				Criteria: "equals",
+				Value:    "interested-parties-users",
+			},
+		},
+	}
+
+	filter, err := ldapConn.BuildLDAPQueryFromSpec(suite.ctx, query)
+
+	assertions.NoError(err)
+	assertions.Equal("(&(memberOf=cn=interested-parties-users,ou=adhoc,ou=managedGroups,dc=redhat,dc=com))", filter)
+}
+
+func (suite *LDAPTestSuite) TestBuildLDAPQueryFromSpec_MemberOfNot() {
+	assertions := assert.New(suite.T())
+
+	ldapConn := &LDAPConn{
+		baseUserDN: "ou=users,dc=redhat,dc=com",
+		baseDN:     "ou=adhoc,ou=managedGroups,dc=redhat,dc=com",
+	}
+
+	query := &v1alpha1.LDAPQuery{
+		Operator: "and",
+		Filters: []v1alpha1.LDAPFilter{
+			{
+				Key:      "manager",
+				Criteria: "equals",
+				Value:    "pbhattac",
+			},
+			{
+				Key:      "memberOf",
+				Criteria: "not",
+				Value:    "excluded-group",
+			},
+		},
+	}
+
+	filter, err := ldapConn.BuildLDAPQueryFromSpec(suite.ctx, query)
+
+	assertions.NoError(err)
+	assertions.Equal("(&(manager=uid=pbhattac,ou=users,dc=redhat,dc=com)(!(memberOf=cn=excluded-group,ou=adhoc,ou=managedGroups,dc=redhat,dc=com)))", filter)
+}
+
+func (suite *LDAPTestSuite) TestBuildLDAPQueryFromSpec_MemberOfOrOperator() {
+	assertions := assert.New(suite.T())
+
+	ldapConn := &LDAPConn{
+		baseUserDN: "ou=users,dc=redhat,dc=com",
+		baseDN:     "ou=adhoc,ou=managedGroups,dc=redhat,dc=com",
+	}
+
+	query := &v1alpha1.LDAPQuery{
+		Operator: "or",
+		Filters: []v1alpha1.LDAPFilter{
+			{
+				Key:      "memberOf",
+				Criteria: "equals",
+				Value:    "team-alpha",
+			},
+			{
+				Key:      "memberOf",
+				Criteria: "equals",
+				Value:    "team-beta",
+			},
+		},
+	}
+
+	filter, err := ldapConn.BuildLDAPQueryFromSpec(suite.ctx, query)
+
+	assertions.NoError(err)
+	assertions.Equal(
+		"(|(memberOf=cn=team-alpha,ou=adhoc,ou=managedGroups,dc=redhat,dc=com)(memberOf=cn=team-beta,ou=adhoc,ou=managedGroups,dc=redhat,dc=com))",
+		filter,
+	)
+}
+
+func (suite *LDAPTestSuite) TestBuildLDAPQueryFromSpec_MemberOfEmptyBaseDN() {
+	assertions := assert.New(suite.T())
+
+	ldapConn := &LDAPConn{
+		baseUserDN: "ou=users,dc=redhat,dc=com",
+		baseDN:     "",
+	}
+
+	query := &v1alpha1.LDAPQuery{
+		Operator: "and",
+		Filters: []v1alpha1.LDAPFilter{
+			{
+				Key:      "memberOf",
+				Criteria: "equals",
+				Value:    "some-group",
+			},
+		},
+	}
+
+	_, err := ldapConn.BuildLDAPQueryFromSpec(suite.ctx, query)
+
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "base DN is empty")
+}


### PR DESCRIPTION
## Summary

Add `memberOf` as a supported `ldap_query` filter key, enabling consumer groups to derive membership from existing Rover/LDAP groups.

## Problem

Teams that manage users in a Rover group for Jira/app access also need those same users in a Dataverse consumer group for Snowflake access. Currently, `ldap_query` only supports individual user attributes (manager, title, costCenter, etc.) — there is no way to derive membership from an existing LDAP/Rover group. This forces dual maintenance of user lists that inevitably drift.

xref: https://redhat.atlassian.net/browse/PLMSAGE-833

## Solution

Add `memberOf` to the supported filter keys, following the same DN expansion pattern as the existing `manager` key:
- `manager` expands: bare username → `uid=<value>,<baseUserDN>`
- `memberOf` expands: bare group name → `cn=<value>,<baseDN>`

### Example usage

```yaml
members:
  ldap_query:
    operator: and
    filters:
    - key: memberOf
      criteria: equals
      value: interested-parties-users
```

### Data flow

```
Rover group (team manages users here)
    ├──► Jira (existing Rover→Jira sync, unchanged)
    └──► LDAP memberOf → Usernaut ldap_query → Snowflake consumer group
```

## Changes

| File | Change |
|---|---|
| `api/v1alpha1/group_types.go` | Add `memberOf` to `LDAPFilter.Key` kubebuilder enum |
| `pkg/clients/ldap/query.go` | Add DN expansion for `memberOf` using `baseDN`; pass `baseDN` through build functions |
| `pkg/clients/ldap/query_test.go` | 4 new test cases (equals, not, or, empty baseDN error) |
| `config/samples/v1alpha1_group_querybased.yaml` | Add commented `memberOf` example |