### PR TITLE
fix: tolerate transient API latency in leader election

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -147,6 +148,9 @@ func main() {
 		watchedNs = "usernaut"
 	}
 
+	leaseDuration := 60 * time.Second
+	renewDeadline := 40 * time.Second
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
@@ -154,6 +158,8 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "dd1e5158.operator.dataverse.redhat.com",
+		LeaseDuration:          &leaseDuration,
+		RenewDeadline:          &renewDeadline,
 		Cache: k8sCache.Options{
 			DefaultNamespaces: map[string]k8sCache.Config{
 				watchedNs: {},


### PR DESCRIPTION
# Changes

## 📝 Description

### What changed?
Leader election: LeaseDuration=60s, RenewDeadline=40s, RetryPeriod=5s (from defaults 15s/10s/2s)
Probe timeoutSeconds=5 (from default 1s)

### Why is this change needed?
Usernaut restarts frequently due to leader election lost after brief API server latency spikes (context deadline exceeded on lease renewal). As a single-replica operator, the aggressive HA defaults provide no failover benefit - they just make the pod crash-prone. Correlated failures across sibling operators on the same node confirm the trigger is cluster-side, but Usernaut's intolerance is the reason it crashes.

### Dependencies
<!-- List any dependencies required for this change -->
- N/A

---

## 🧪 Testing

### Test Coverage
<!-- Describe the tests you ran and how your change affects other areas -->

### Performance Impact
<!-- Describe any performance impact (positive or negative) and how you measured it -->
- N/A

---

## 🚀 Deployment

### Deploy Steps
<!-- Outline steps to deploy this to production -->
1. N/A

### Prerequisites
<!-- List any prerequisites before deployment -->
- N/A

### Post-Deployment Monitoring
<!-- What should be monitored after deployment? -->
- N/A

### Rollback Plan
<!-- How to rollback if issues arise -->
- N/A

---

## ⚠️ Breaking Changes

<!-- If there are backward incompatible changes, list them here and describe how they're being handled -->
- [ ] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

**Details:**

<!-- If you checked "This PR contains breaking changes", please provide details on the breaking changes and a migration path. -->
- N/A

---

## ⚙️ Configuration Changes

<!-- List any config changes, additions, or modifications -->
- N/A

---

## ✅ Developer Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added positive and negative tests that prove my fix is effective or that my feature works
- [ ] Relevant documentation (README, tech specs, etc.) has been added or updated
- [ ] All CI/CD checks are passing
