### PR TITLE
Drop timeout from context to avoid pod restarts

### DIFF
--- a/pkg/clients/snowflake/client.go
+++ b/pkg/clients/snowflake/client.go
@@ -127,9 +127,7 @@ func (c *SnowflakeClient) makeRequestWithPolling(ctx context.Context, endpoint,
 		return nil, nil, status, fmt.Errorf("received 202 response but no Location header found")
 	}
 
-	pollCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-	return c.pollForResults(pollCtx, location)
+	return c.pollForResults(ctx, location)
 }
 
 // pollForResults polls every 10 seconds until the endpoint returns 200


### PR DESCRIPTION
# Changes

In case of snowflake, if the query times out or if there is a delay in getting the response, the connection is closed.

## 📝 Description

### What changed?
<!-- Describe the current behavior vs. the new behavior -->

### Why is this change needed?
<!-- Explain the problem this PR solves -->

### Dependencies
<!-- List any dependencies required for this change -->
- N/A

---

## 🧪 Testing

### Test Coverage
<!-- Describe the tests you ran and how your change affects other areas -->

### Performance Impact
<!-- Describe any performance impact (positive or negative) and how you measured it -->
- N/A

---

## 🚀 Deployment

### Deploy Steps
<!-- Outline steps to deploy this to production -->
1. N/A

### Prerequisites
<!-- List any prerequisites before deployment -->
- N/A

### Post-Deployment Monitoring
<!-- What should be monitored after deployment? -->
- N/A

### Rollback Plan
<!-- How to rollback if issues arise -->
- N/A

---

## ⚠️ Breaking Changes

<!-- If there are backward incompatible changes, list them here and describe how they're being handled -->
- [ ] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

**Details:**

<!-- If you checked "This PR contains breaking changes", please provide details on the breaking changes and a migration path. -->
- N/A

---

## ⚙️ Configuration Changes

<!-- List any config changes, additions, or modifications -->
- N/A

---

## ✅ Developer Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added positive and negative tests that prove my fix is effective or that my feature works
- [ ] Relevant documentation (README, tech specs, etc.) has been added or updated
- [ ] All CI/CD checks are passing
