### PR TITLE
Set binding credential in LDAPConn for further use

### DIFF
--- a/pkg/clients/ldap/client.go
+++ b/pkg/clients/ldap/client.go
@@ -76,6 +76,8 @@ func InitLdap(ldapConfig LDAP) (LDAPClient, error) {
 		baseUserDN:       ldapConfig.BaseUserDN,
 		userSearchFilter: ldapConfig.UserSearchFilter,
 		attributes:       ldapConfig.Attributes,
+		bindUsername:     ldapConfig.BindUsername,
+		bindPassword:     ldapConfig.BindPassword,
 	}, nil
 }
 


### PR DESCRIPTION
# Changes

the bindUsername and bindPassword were getting set in InitLdap function properly but the next time getConn tries to refresh the client, it was moving to anonymous bind.

Fix: Set the bindUsername and bindPassword in LDAPConn struct so that same can be leveraged later.

## 📝 Description

### What changed?
<!-- Describe the current behavior vs. the new behavior -->

### Why is this change needed?
<!-- Explain the problem this PR solves -->

### Dependencies
<!-- List any dependencies required for this change -->
- N/A

---

## 🧪 Testing

### Test Coverage
<!-- Describe the tests you ran and how your change affects other areas -->

### Performance Impact
<!-- Describe any performance impact (positive or negative) and how you measured it -->
- N/A

---

## 🚀 Deployment

### Deploy Steps
<!-- Outline steps to deploy this to production -->
1. N/A

### Prerequisites
<!-- List any prerequisites before deployment -->
- N/A

### Post-Deployment Monitoring
<!-- What should be monitored after deployment? -->
- N/A

### Rollback Plan
<!-- How to rollback if issues arise -->
- N/A

---

## ⚠️ Breaking Changes

<!-- If there are backward incompatible changes, list them here and describe how they're being handled -->
- [~] This PR contains breaking changes
- [~] Migration guide provided (if applicable)

**Details:**

<!-- If you checked "This PR contains breaking changes", please provide details on the breaking changes and a migration path. -->
- N/A

---

## ⚙️ Configuration Changes

<!-- List any config changes, additions, or modifications -->
- N/A

---

## ✅ Developer Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [~] I have commented my code, particularly in hard-to-understand areas
- [~] I have added positive and negative tests that prove my fix is effective or that my feature works
- [~] Relevant documentation (README, tech specs, etc.) has been added or updated
- [X] All CI/CD checks are passing
