### PR TITLE
Add support for multiple watches namespaces

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -136,7 +136,7 @@ Welcome to Usernaut! This guide provides a comprehensive overview of the project
 ### Architecture Highlights
 
 - **Controller Pattern**: Follows the Kubernetes controller pattern - watch, reconcile, update status
-- **Namespace-Scoped**: Watches only the `usernaut` namespace by default (configurable via `WATCHED_NAMESPACE` env var)
+- **Namespace-Scoped**: Watches only the `usernaut` namespace by default (configurable via the `WATCHED_NAMESPACE` env var, which accepts a comma separated list of namespaces, e.g. `usernaut,dataverse`)
 - **Shared Cache Mutex**: A `sync.RWMutex` shared between controllers prevents race conditions during cache read/write operations
 - **All-or-Nothing Cache Updates**: Cache indexes (user:groups, group members, user_list) are only updated if ALL backends succeed. If any backend fails, no cache indexes are updated to maintain consistency. Individual user/team cache entries are updated per-backend during processing.
 - **Finalizers**: Ensure proper cleanup when Group CRs are deleted

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,10 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"maps"
 	"os"
+	"slices"
+	"strings"
 	"sync"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -57,6 +60,8 @@ import (
 	// +kubebuilder:scaffold:imports
 	"github.com/redhat-data-and-ai/usernaut/internal/httpapi/server"
 )
+
+const defaultWatchedNamespace = "usernaut"
 
 var (
 	scheme   = runtime.NewScheme()
@@ -142,10 +147,8 @@ func main() {
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
-	watchedNs := os.Getenv("WATCHED_NAMESPACE")
-	if watchedNs == "" {
-		watchedNs = "usernaut"
-	}
+	watchedNamespaces := parseWatchedNamespaces(os.Getenv("WATCHED_NAMESPACE"))
+	setupLog.Info("watching namespaces", "namespaces", slices.Sorted(maps.Keys(watchedNamespaces)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
@@ -155,9 +158,7 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "dd1e5158.operator.dataverse.redhat.com",
 		Cache: k8sCache.Options{
-			DefaultNamespaces: map[string]k8sCache.Config{
-				watchedNs: {},
-			},
+			DefaultNamespaces: watchedNamespaces,
 		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
@@ -264,6 +265,24 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+// parseWatchedNamespaces parses a comma separated list of namespaces into the cache
+// configuration consumed by the manager. It falls back to the "usernaut" namespace when
+// no usable value is provided.
+func parseWatchedNamespaces(value string) map[string]k8sCache.Config {
+	namespaces := make(map[string]k8sCache.Config)
+	for _, ns := range strings.Split(value, ",") {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			namespaces[ns] = k8sCache.Config{}
+		}
+	}
+
+	if len(namespaces) == 0 {
+		namespaces[defaultWatchedNamespace] = k8sCache.Config{}
+	}
+
+	return namespaces
 }
 
 // storeUsersInCache stores users in the cache and returns an error if any user fails to be stored

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8sCache "sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+func TestParseWatchedNamespaces(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected map[string]k8sCache.Config
+	}{
+		{
+			name:     "empty value falls back to the default namespace",
+			value:    "",
+			expected: map[string]k8sCache.Config{defaultWatchedNamespace: {}},
+		},
+		{
+			name:     "only separators falls back to the default namespace",
+			value:    " , ,",
+			expected: map[string]k8sCache.Config{defaultWatchedNamespace: {}},
+		},
+		{
+			name:     "single namespace",
+			value:    "usernaut",
+			expected: map[string]k8sCache.Config{"usernaut": {}},
+		},
+		{
+			name:  "comma separated namespaces are trimmed and deduplicated",
+			value: " usernaut , dataverse ,,usernaut, tenant-a ",
+			expected: map[string]k8sCache.Config{
+				"usernaut":  {},
+				"dataverse": {},
+				"tenant-a":  {},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parseWatchedNamespaces(tt.value))
+		})
+	}
+}


### PR DESCRIPTION
# Changes

At the moment Usernaut watches for one namespace but in cases where teams want to manage their CRs in different namespaces, usernaut should be able to look for that.

## 📝 Description

### What changed?
<!-- Describe the current behavior vs. the new behavior -->

### Why is this change needed?
<!-- Explain the problem this PR solves -->

### Dependencies
<!-- List any dependencies required for this change -->
- N/A

---

## 🧪 Testing

### Test Coverage
<!-- Describe the tests you ran and how your change affects other areas -->

### Performance Impact
<!-- Describe any performance impact (positive or negative) and how you measured it -->
- N/A

---

## 🚀 Deployment

### Deploy Steps
<!-- Outline steps to deploy this to production -->
1. N/A

### Prerequisites
<!-- List any prerequisites before deployment -->
- N/A

### Post-Deployment Monitoring
<!-- What should be monitored after deployment? -->
- N/A

### Rollback Plan
<!-- How to rollback if issues arise -->
- N/A

---

## ⚠️ Breaking Changes

<!-- If there are backward incompatible changes, list them here and describe how they're being handled -->
- [ ] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

**Details:**

<!-- If you checked "This PR contains breaking changes", please provide details on the breaking changes and a migration path. -->
- N/A

---

## ⚙️ Configuration Changes

<!-- List any config changes, additions, or modifications -->
- N/A

---

## ✅ Developer Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added positive and negative tests that prove my fix is effective or that my feature works
- [ ] Relevant documentation (README, tech specs, etc.) has been added or updated
- [ ] All CI/CD checks are passing
