### PR TITLE
add error message on spec valdiation failure

### DIFF
--- a/api/v1alpha1/group_types.go
+++ b/api/v1alpha1/group_types.go
@@ -127,37 +127,30 @@ func init() {
 }
 
 func (c *Group) SetWaiting() {
-	condition := metav1.Condition{
-		Type:               GroupReadyCondition,
-		LastTransitionTime: metav1.Now(),
-		Status:             metav1.ConditionUnknown,
-		Message:            "Group is getting reconciled",
-		Reason:             "Waiting",
-	}
-	for i, currentCondition := range c.Status.Conditions {
-		if currentCondition.Type == condition.Type {
-			c.Status.Conditions[i] = condition
-			return
-		}
-	}
-	c.Status.Conditions = append(c.Status.Conditions, condition)
+	c.setReadyCondition(metav1.ConditionUnknown, "Waiting", "Group is getting reconciled")
 }
 
 func (c *Group) UpdateStatus(isError bool) {
+	if isError {
+		c.setReadyCondition(metav1.ConditionFalse, ReconcileFailed, "Group reconcile failed")
+		return
+	}
+
+	c.Status.LastAppliedGeneration = c.Generation
+	c.setReadyCondition(metav1.ConditionTrue, SuccessfullyReconciled, "Group reconciled successfully")
+}
+
+func (c *Group) UpdateStatusWithErrMessage(errMessage string) {
+	c.setReadyCondition(metav1.ConditionFalse, ReconcileFailed, errMessage)
+}
+
+func (c *Group) setReadyCondition(status metav1.ConditionStatus, reason, message string) {
 	condition := metav1.Condition{
 		Type:               GroupReadyCondition,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
 		LastTransitionTime: metav1.Now(),
-	}
-	if !isError {
-		condition.Status = metav1.ConditionTrue
-		condition.Message = "Group reconciled successfully"
-		condition.Reason = SuccessfullyReconciled
-
-		c.Status.LastAppliedGeneration = c.Generation
-	} else {
-		condition.Status = metav1.ConditionFalse
-		condition.Message = "Group reconcile failed"
-		condition.Reason = ReconcileFailed
 	}
 	for i, currentCondition := range c.Status.Conditions {
 		if currentCondition.Type == condition.Type {

--- a/api/v1alpha1/group_types_test.go
+++ b/api/v1alpha1/group_types_test.go
@@ -1,0 +1,30 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGroupUpdateValidationFailed(t *testing.T) {
+	group := &Group{}
+	group.UpdateStatusWithErrMessage(`spec.group_name must start with "aif-"`)
+
+	if len(group.Status.Conditions) != 1 {
+		t.Fatalf("expected 1 condition, got %d", len(group.Status.Conditions))
+	}
+
+	condition := group.Status.Conditions[0]
+	if condition.Type != GroupReadyCondition {
+		t.Fatalf("expected type %q, got %q", GroupReadyCondition, condition.Type)
+	}
+	if condition.Status != metav1.ConditionFalse {
+		t.Fatalf("expected status False, got %q", condition.Status)
+	}
+	if condition.Reason != ReconcileFailed {
+		t.Fatalf("expected reason %q, got %q", ReconcileFailed, condition.Reason)
+	}
+	if condition.Message != `spec.group_name must start with "aif-"` {
+		t.Fatalf("unexpected message: %q", condition.Message)
+	}
+}

--- a/internal/controller/group_controller.go
+++ b/internal/controller/group_controller.go
@@ -111,7 +111,7 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if err := validate(req.Namespace, groupCR, r.AppConfig.ControllerConfig.SpecValidationRules); err != nil {
 		r.log.WithError(err).Warn("spec validation failed")
-		groupCR.UpdateStatus(true)
+		groupCR.UpdateStatusWithErrMessage(err.Error())
 		if statusErr := r.Status().Update(ctx, groupCR); statusErr != nil {
 			r.log.WithError(statusErr).Error("error updating status after spec validation failure")
 			return ctrl.Result{}, statusErr


### PR DESCRIPTION
# Changes

## 📝 Description

### What changed?
Before: When Group spec validation failed (e.g. invalid group_name prefix or disallowed backend type), the CR was marked Ready=False with a generic message "Group reconcile failed". The specific validation error was only visible in operator logs.

After: Validation failures call UpdateStatusWithErrMessage(err.Error()), so the GroupReadyCondition message contains the actual validation error (e.g. spec.group_name must start with "aif-"). Backend reconcile failures still use UpdateStatus(true) with the generic message. Status helpers were refactored via a shared setReadyCondition method.

### Why is this change needed?
Operators and cluster users need to see why a Group failed validation without digging through pod logs. The Group CR already exposes a Message column in kubectl get groups; this change surfaces the validation error there.

### Dependencies
<!-- List any dependencies required for this change -->
- N/A

---

## 🧪 Testing

### Test Coverage
<!-- Describe the tests you ran and how your change affects other areas -->

### Performance Impact
<!-- Describe any performance impact (positive or negative) and how you measured it -->
- N/A

---

## 🚀 Deployment

### Deploy Steps
<!-- Outline steps to deploy this to production -->
1. N/A

### Prerequisites
<!-- List any prerequisites before deployment -->
- N/A

### Post-Deployment Monitoring
<!-- What should be monitored after deployment? -->
- N/A

### Rollback Plan
<!-- How to rollback if issues arise -->
- N/A

---

## ⚠️ Breaking Changes

<!-- If there are backward incompatible changes, list them here and describe how they're being handled -->
- [ ] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

**Details:**

<!-- If you checked "This PR contains breaking changes", please provide details on the breaking changes and a migration path. -->
- N/A

---

## ⚙️ Configuration Changes

<!-- List any config changes, additions, or modifications -->
- N/A

---

## ✅ Developer Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added positive and negative tests that prove my fix is effective or that my feature works
- [ ] Relevant documentation (README, tech specs, etc.) has been added or updated
- [ ] All CI/CD checks are passing
