### PR TITLE
Fix: detect untrustworthy LDAP search results during IPA reinit

### DIFF
--- a/pkg/clients/ldap/query.go
+++ b/pkg/clients/ldap/query.go
@@ -43,6 +43,14 @@ func (l *LDAPConn) GetQueryMembers(ctx context.Context, query string) ([]string,
 		log.WithError(err).Error("failed to search LDAP for query members")
 		return nil, err
 	}
+	_, diagnostic, _ := searchResultMeta(resp, nil)
+	if len(resp.Entries) == 0 && diagnostic != "" {
+		log.WithField("ldap_diagnostic_message", diagnostic).
+			Error("LDAP query search returned no entries with diagnostic message")
+		return nil, fmt.Errorf("%w: resultCode=%d diagnostic=%q",
+			ErrLDAPUntrustworthyResult, resp.ResultCode, diagnostic)
+	}
+
 	log.WithField("entries", len(resp.Entries)).Info("LDAP search results")
 	if len(resp.Entries) == 0 {
 		log.Info("no LDAP entries found for query; returning empty member list")

--- a/pkg/clients/ldap/query_test.go
+++ b/pkg/clients/ldap/query_test.go
@@ -621,3 +621,25 @@ func (suite *LDAPTestSuite) TestBuildLDAPQueryFromSpec_ExceedsMaxDepth() {
 	assertions.Error(err)
 	assertions.Contains(err.Error(), "exceeds maximum depth")
 }
+
+func (suite *LDAPTestSuite) TestGetQueryMembers_DiagnosticWithZeroEntries_Fails() {
+	assertions := assert.New(suite.T())
+
+	ldapConn := &LDAPConn{
+		conn:       suite.ldapClient,
+		baseUserDN: "ou=users,dc=example,dc=com",
+		server:     "ldap://ldap.com:389",
+	}
+
+	suite.ldapClient.EXPECT().IsClosing().Return(false).Times(1)
+	suite.ldapClient.EXPECT().Search(gomock.Any()).Return(&ldap.SearchResult{
+		Entries:           []*ldap.Entry{},
+		ResultCode:        ldap.LDAPResultSuccess,
+		DiagnosticMessage: "IPA: directory is reinitializing",
+	}, nil).Times(1)
+
+	resp, err := ldapConn.GetQueryMembers(suite.ctx, "(objectClass=groupOfNames)")
+
+	assertions.ErrorIs(err, ErrLDAPUntrustworthyResult)
+	assertions.Nil(resp)
+}

--- a/pkg/clients/ldap/search_result.go
+++ b/pkg/clients/ldap/search_result.go
@@ -1,0 +1,37 @@
+package ldap
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/go-ldap/ldap/v3"
+)
+
+// ErrLDAPUntrustworthyResult is returned when Search completed without a
+// library error (often resultCode 0) but the response cannot be treated as a
+// complete user list. IPA may return success with an empty entry list and a
+// diagnostic message while the directory is not ready (for example during reinit).
+var ErrLDAPUntrustworthyResult = errors.New("LDAP search result is untrustworthy")
+
+// searchResultMeta extracts resultCode, diagnosticMessage and entry count from
+// a Search reply. It reads from the SearchResult struct first, then falls back
+// to the ldap.Error if present (e.g. when the server returned a non-zero code).
+func searchResultMeta(resp *ldap.SearchResult, err error) (code uint16, diagnostic string, n int) {
+	if resp != nil {
+		code = resp.ResultCode
+		diagnostic = strings.TrimSpace(resp.DiagnosticMessage)
+		n = len(resp.Entries)
+	}
+	if err != nil {
+		var ldapErr *ldap.Error
+		if errors.As(err, &ldapErr) {
+			if code == 0 {
+				code = ldapErr.ResultCode
+			}
+			if diagnostic == "" && ldapErr.Err != nil {
+				diagnostic = strings.TrimSpace(ldapErr.Err.Error())
+			}
+		}
+	}
+	return code, diagnostic, n
+}

--- a/pkg/clients/ldap/search_result_test.go
+++ b/pkg/clients/ldap/search_result_test.go
@@ -1,0 +1,68 @@
+package ldap
+
+import (
+	"errors"
+	"testing"
+
+	ber "github.com/go-asn1-ber/asn1-ber"
+	"github.com/go-ldap/ldap/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func searchResultDonePacket(resultCode int64, diagnostic string) *ber.Packet {
+	done := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ldap.ApplicationSearchResultDone, nil, "Search Result Done")
+	done.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, resultCode, "resultCode"))
+	done.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "matchedDN"))
+	done.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, diagnostic, "diagnosticMessage"))
+
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Message")
+	packet.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, 1, "messageID"))
+	packet.AppendChild(done)
+	return packet
+}
+
+func TestParseLDAPResult_SuccessKeepsDiagnostic(t *testing.T) {
+	packet := searchResultDonePacket(0, "IPA: server is reinitializing")
+
+	require.Nil(t, ldap.GetLDAPError(packet), "go-ldap treats resultCode 0 as success and returns nil")
+
+	code, _, diagnostic := ldap.ParseLDAPResult(packet)
+	assert.Equal(t, uint16(ldap.LDAPResultSuccess), code)
+	assert.Equal(t, "IPA: server is reinitializing", diagnostic)
+}
+
+func TestParseLDAPResult_NonZeroKeepsDiagnostic(t *testing.T) {
+	packet := searchResultDonePacket(int64(ldap.LDAPResultBusy), "server busy")
+
+	err := ldap.GetLDAPError(packet)
+	require.Error(t, err)
+	var ldapErr *ldap.Error
+	require.ErrorAs(t, err, &ldapErr)
+	assert.Equal(t, uint16(ldap.LDAPResultBusy), ldapErr.ResultCode)
+	assert.Equal(t, "server busy", ldapErr.Err.Error())
+
+	code, _, diagnostic := ldap.ParseLDAPResult(packet)
+	assert.Equal(t, uint16(ldap.LDAPResultBusy), code)
+	assert.Equal(t, "server busy", diagnostic)
+}
+
+func TestSearchResultMeta_FromSearchResultOnSuccess(t *testing.T) {
+	resp := &ldap.SearchResult{
+		ResultCode:        ldap.LDAPResultSuccess,
+		DiagnosticMessage: "  IPA reinit  ",
+		Entries:           []*ldap.Entry{},
+	}
+	code, diagnostic, n := searchResultMeta(resp, nil)
+	assert.Equal(t, uint16(ldap.LDAPResultSuccess), code)
+	assert.Equal(t, "IPA reinit", diagnostic)
+	assert.Equal(t, 0, n)
+}
+
+func TestSearchResultMeta_FromLDAPError(t *testing.T) {
+	err := ldap.NewError(ldap.LDAPResultUnavailable, errors.New("not ready"))
+	code, diagnostic, n := searchResultMeta(nil, err)
+	assert.Equal(t, uint16(ldap.LDAPResultUnavailable), code)
+	assert.Equal(t, "not ready", diagnostic)
+	assert.Equal(t, 0, n)
+}

--- a/pkg/clients/ldap/user.go
+++ b/pkg/clients/ldap/user.go
@@ -52,6 +52,14 @@ func (l *LDAPConn) executeSearch(ctx context.Context,
 		return nil, err
 	}
 
+	_, diagnostic, _ := searchResultMeta(resp, nil)
+	if len(resp.Entries) == 0 && diagnostic != "" {
+		log.WithField("ldap_diagnostic_message", diagnostic).
+			Error("LDAP search returned no entries with diagnostic message")
+		return nil, fmt.Errorf("%w: resultCode=%d diagnostic=%q",
+			ErrLDAPUntrustworthyResult, resp.ResultCode, diagnostic)
+	}
+
 	if len(resp.Entries) == 0 {
 		log.Warn("no LDAP entries found")
 		return nil, ErrNoUserFound
@@ -164,6 +172,17 @@ func (l *LDAPConn) GetBulkUserLDAPData(
 				"bulk LDAP search failed (batch %d/%d, %d users, start offset %d): %w",
 				batchNum, totalBatches, len(batch), batchStart, err,
 			)
+		}
+
+		_, diagnostic, _ := searchResultMeta(resp, nil)
+		if len(resp.Entries) == 0 && diagnostic != "" {
+			log.WithField("ldap_diagnostic_message", diagnostic).
+				WithField("batch_start", batchStart).
+				WithField("batch", fmt.Sprintf("%d/%d", batchNum, totalBatches)).
+				WithField("batch_user_ids", batch).
+				Error("bulk LDAP batch returned no entries with diagnostic message")
+			return result, fmt.Errorf("%w: resultCode=%d diagnostic=%q",
+				ErrLDAPUntrustworthyResult, resp.ResultCode, diagnostic)
 		}
 
 		log.WithField("batch_start", batchStart).WithField("entries", len(resp.Entries)).

--- a/pkg/clients/ldap/user_test.go
+++ b/pkg/clients/ldap/user_test.go
@@ -460,3 +460,76 @@ func (suite *LDAPTestSuite) TestGetBulkUserLDAPData_ContextCanceledStopsAfterFir
 	assertions.Len(out, 1)
 	assertions.Contains(out, "a1")
 }
+
+func (suite *LDAPTestSuite) TestGetUserLDAPData_DiagnosticWithZeroEntries_Fails() {
+	assertions := assert.New(suite.T())
+
+	ldapConn := &LDAPConn{
+		conn:             suite.ldapClient,
+		userDN:           "uid=%s,ou=users,dc=example,dc=com",
+		baseDN:           "ou=adhoc,ou=managedGroups,dc=example,dc=com",
+		server:           "ldap://ldap.com:389",
+		userSearchFilter: "(objectClass=uid)",
+		attributes:       []string{"mail"},
+	}
+
+	suite.ldapClient.EXPECT().IsClosing().Return(false).Times(1)
+	suite.ldapClient.EXPECT().Search(gomock.Any()).Return(&ldap.SearchResult{
+		Entries:           []*ldap.Entry{},
+		ResultCode:        ldap.LDAPResultSuccess,
+		DiagnosticMessage: "IPA: directory is reinitializing",
+	}, nil).Times(1)
+
+	resp, err := ldapConn.GetUserLDAPData(suite.ctx, "testuser")
+
+	assertions.ErrorIs(err, ErrLDAPUntrustworthyResult)
+	assertions.Nil(resp)
+}
+
+func (suite *LDAPTestSuite) TestGetUserLDAPDataByEmail_DiagnosticWithZeroEntries_Fails() {
+	assertions := assert.New(suite.T())
+
+	ldapConn := &LDAPConn{
+		conn:             suite.ldapClient,
+		baseUserDN:       "ou=users,dc=example,dc=com",
+		server:           "ldap://ldap.com:389",
+		userSearchFilter: "(objectClass=person)",
+		attributes:       []string{"mail"},
+	}
+
+	suite.ldapClient.EXPECT().IsClosing().Return(false).Times(1)
+	suite.ldapClient.EXPECT().Search(gomock.Any()).Return(&ldap.SearchResult{
+		Entries:           []*ldap.Entry{},
+		ResultCode:        ldap.LDAPResultSuccess,
+		DiagnosticMessage: "IPA: directory is reinitializing",
+	}, nil).Times(1)
+
+	resp, err := ldapConn.GetUserLDAPDataByEmail(suite.ctx, "testuser@example.com")
+
+	assertions.ErrorIs(err, ErrLDAPUntrustworthyResult)
+	assertions.Nil(resp)
+}
+
+func (suite *LDAPTestSuite) TestGetBulkUserLDAPData_DiagnosticWithZeroEntries_Fails() {
+	assertions := assert.New(suite.T())
+
+	ldapConn := &LDAPConn{
+		conn:             suite.ldapClient,
+		baseUserDN:       "ou=users,dc=example,dc=com",
+		server:           "ldap://ldap.com:389",
+		userSearchFilter: "(objectClass=person)",
+		attributes:       []string{"mail", "uid"},
+	}
+
+	suite.ldapClient.EXPECT().IsClosing().Return(false).Times(1)
+	suite.ldapClient.EXPECT().Search(gomock.Any()).Return(&ldap.SearchResult{
+		Entries:           []*ldap.Entry{},
+		ResultCode:        ldap.LDAPResultSuccess,
+		DiagnosticMessage: "IPA: directory is reinitializing",
+	}, nil).Times(1)
+
+	resp, err := ldapConn.GetBulkUserLDAPData(suite.ctx, []string{"testuser"})
+
+	assertions.ErrorIs(err, ErrLDAPUntrustworthyResult)
+	assertions.Empty(resp)
+}


### PR DESCRIPTION
## Problem
When Red Hat IPA is reinitializing (e.g. during replica sync), it returns LDAP search responses with `resultCode=0` (success), zero user entries, and a `diagnosticMessage` indicating its state. Usernaut's LDAP client previously treated any successful search with zero entries as "users not found", which led to false-positive offboarding — active users were incorrectly removed from backends because the directory appeared empty.

## Fix
After every `conn.Search()` call, check whether the response has zero entries **and** a non-empty diagnostic message. If both conditions are true, return `ErrLDAPUntrustworthyResult` instead of treating the result as a normal empty response. This prevents the controller from proceeding with offboarding when the directory is not in a reliable state.

The check is applied in three places:
- `executeSearch` — used by `GetUserLDAPData` and `GetUserLDAPDataByEmail`
- `GetBulkUserLDAPData` — batch user lookup during group reconciliation
- `GetQueryMembers` — LDAP query-based group membership

When entries are returned (even with a diagnostic message), the search is treated as valid.

## Dependency

This PR depends on a change to `go-ldap/ldap` that exposes `ResultCode` and `DiagnosticMessage` on the `SearchResult` struct (upstream currently discards the diagnostic message when `resultCode=0`).

Upstream PR: https://github.com/go-ldap/ldap/pull/626

Once the upstream change is merged and released, we will update `go.mod` to the new version. Until then, this PR will not compile against the current `go-ldap v3.4.13`.